### PR TITLE
Disable zoom on iPhone

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="de">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no" />
   <title>Tetris – Vanilla JS (Einzeldatei) + Scoreboard</title>
   <!-- iOS/PWA -->
   <meta name="apple-mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
## Summary
- prevent pinch and double-tap zoom on mobile by restricting viewport scaling

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f2a1021d0832b9611aaa21e7ecf46