### PR TITLE
Prevent mobile scrolling and hide page overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <link rel="apple-touch-icon" href="icons/icon-180.png" />
   <style>
     :root { --bg:#0f1115; --fg:#e8eaed; --muted:#a7b0be; --accent:#6ee7ff; }
-    html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font:500 16px/1.4 system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
+    html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font:500 16px/1.4 system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;overflow:hidden}
     .wrap{max-width:980px;margin:24px auto;padding:0 16px;display:grid;grid-template-columns:1fr auto;gap:24px}
     h1{font-size:28px;margin:0 0 8px}
     p{color:var(--muted);margin:0 0 12px}
@@ -49,7 +49,7 @@
     #overlay h2{margin:0 0 6px}
     @keyframes pop{from{transform:scale(.95);opacity:.6} to{transform:scale(1);opacity:1}}
     /* Pause Overlay */
-    .board-wrap{position:relative}
+    .board-wrap{position:relative;touch-action:none}
     #pauseOverlay{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-weight:800;font-size:48px;letter-spacing:2px;color:#e8eaed;background:rgba(0,0,0,.35);opacity:0;pointer-events:none;transition:opacity .2s ease;border-radius:12px}
     #pauseOverlay.show{opacity:1}
     /* Mobile touch controls */


### PR DESCRIPTION
## Summary
- Add `overflow:hidden` to `html, body` to hide scrollbars
- Disable touch scrolling on the game board with `touch-action:none`

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a063f10378832b89bba29e3f5ea1c9