### PR TITLE
Show score and mode above board

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     }
     .panel{background:#161a23;border:1px solid #242a36;border-radius:16px;padding:14px 16px;box-shadow:0 10px 30px rgba(0,0,0,.2)}
     canvas{display:block;background:#0a0c10;border-radius:12px;border:1px solid #202533}
-    .stats{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:8px}
+    .stats{display:grid;grid-template-columns:1fr 1fr;gap:8px}
     .stat{background:#0d1119;border:1px solid #1f2533;border-radius:12px;padding:10px;text-align:center}
     .stat b{display:block;font-size:22px;margin-top:6px;color:var(--accent)}
     .buttons{display:flex;gap:8px;flex-wrap:wrap;margin-top:12px}
@@ -69,17 +69,13 @@
       <button id="btnMenu" style="margin-bottom:8px">Menü</button>
       <div class="grid">
         <div class="panel">
-          <div class="board-wrap">
-            <canvas id="game" width="300" height="600" aria-label="Tetris Board"></canvas>
-            <div id="pauseOverlay" aria-hidden="true">PAUSE</div>
-          </div>
-          <div class="stats">
+          <div class="stats" style="margin-bottom:8px">
             <div class="stat">Score<b id="score">0</b></div>
             <div class="stat">Level<b id="level">1</b></div>
             <div class="stat">Lines<b id="lines">0</b></div>
             <div class="stat">Best<b id="best">0</b></div>
           </div>
-          <div class="controls" style="margin-top:8px">
+          <div class="controls" style="margin:0 0 8px">
             <label>Modus:
               <select id="modeSelect">
                 <option value="classic">Classic (endlos)</option>
@@ -87,6 +83,10 @@
               </select>
             </label>
             <span class="timer" id="timer" style="margin-left:auto"></span>
+          </div>
+          <div class="board-wrap">
+            <canvas id="game" width="300" height="600" aria-label="Tetris Board"></canvas>
+            <div id="pauseOverlay" aria-hidden="true">PAUSE</div>
           </div>
           <div class="buttons">
             <button id="btnStart">Start/Neu</button>


### PR DESCRIPTION
## Summary
- Ensure score and mode controls remain visible when scrolling is disabled by moving them above the Tetris board
- Adjust CSS for stats to remove default top margin so layout fits on smaller screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a06e3824cc832bb6cb988c1e8b9f99