### PR TITLE
feat: clarify mobile controls and desktop keys

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
           <div class="buttons">
             <button id="btnStart">Start/Neu</button>
             <button id="btnPause">Pause</button>
-            <button id="btnHard">Hard Drop (Leertaste)</button>
+            <button id="btnHard">Hard Drop</button>
           </div>
           <div class="tag" id="comboTag"></div>
         </div>
@@ -55,11 +55,13 @@
               <canvas id="next" class="mini" width="120" height="120"></canvas>
             </div>
             <div>
-              <div class="tag">Hold (<kbd>Shift</kbd>)</div>
+              <div class="tag">Hold</div>
               <canvas id="hold" class="mini" width="120" height="120"></canvas>
             </div>
           </div>
           <h3>Steuerung</h3>
+          <p>Nutze die Bildschirm-Buttons (◀︎/▶︎/⟳/HOLD/Soft/HARD/Pause/Neu) auf Mobilgeräten.</p>
+          <p>Auf Desktop funktionieren zusätzlich folgende Tasten:</p>
           <ul>
             <li><kbd>←</kbd>/<kbd>→</kbd>: bewegen</li>
             <li><kbd>↓</kbd>: schneller fallen (Soft Drop)</li>


### PR DESCRIPTION
## Summary
- emphasize mobile buttons and list optional desktop keyboard controls
- remove PC-only hints from buttons and Hold display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a085575044832b83789e82fdd883da