### PR TITLE
feat: add mode-specific highscores and timer start

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
       <button id="tabSettings">Einstellungen</button>
     </div>
     <div class="panel" id="scorePanel" style="margin-top:16px;">
-      <h3>Scoreboard</h3>
+      <h3>Scoreboard – <span id="hsModeLabel">Classic</span></h3>
       <div class="controls">
         <label for="playerName">Name:</label>
         <input id="playerName" class="input" placeholder="Dein Name" maxlength="16" />


### PR DESCRIPTION
## Summary
- Start Ultra mode timer at 2 minutes when mode is selected
- Maintain separate highscore lists and best scores for each game mode
- Display current mode in scoreboard header

## Testing
- `node --check tetris.js`

------
https://chatgpt.com/codex/tasks/task_e_68a0898f9700832b843736e53a622a60