### PR TITLE
Move start/pause controls to top bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,8 @@
       <div class="controls top-controls">
         <button id="btnMenu">Menü</button>
         <button id="themeToggle">Theme</button>
+        <button id="btnStart">Start/Neu</button>
+        <button id="btnPause">Pause</button>
         <label>Modus:
           <select id="modeSelect">
             <option value="classic">Classic (endlos)</option>
@@ -45,8 +47,6 @@
             </div>
           </div>
           <div class="buttons">
-            <button id="btnStart">Start/Neu</button>
-            <button id="btnPause">Pause</button>
             <button id="btnHard">Hard Drop</button>
           </div>
           <div class="tag" id="comboTag"></div>

--- a/styles.css
+++ b/styles.css
@@ -49,7 +49,7 @@ ul{padding-left:18px;margin:6px 0}
 .footer{grid-column:1/-1;color:var(--muted);margin-top:8px}
 .tag{font-size:12px;color:var(--muted)}
 .controls{display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin:10px 0}
-.top-controls{margin-bottom:8px}
+.top-controls{margin-bottom:8px;gap:8px;flex-wrap:wrap}
 .input{background:var(--input-bg);border:1px solid var(--input-border);border-radius:10px;padding:8px 10px;color:var(--fg)}
 .table{width:100%;border-collapse:collapse;margin-top:8px}
 .table th,.table td{border:1px solid var(--table-border);padding:8px;text-align:left}


### PR DESCRIPTION
## Summary
- Relocate Start and Pause buttons into the top control bar and leave Hard Drop alone in the lower button section.
- Ensure top control bar spaces multiple buttons by explicitly setting flex-wrap and gap.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a08dbb36a4832b91f5996835e22545