### PR TITLE
Remove bottom score display and hard drop button

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,14 +41,8 @@
               <canvas id="game" width="300" height="600" aria-label="Tetris Board"></canvas>
               <div id="pauseOverlay" aria-hidden="true">PAUSE</div>
             </div>
-            <div class="stats">
-              <div class="stat">Score<b id="score">0</b></div>
-              <div class="stat">Best<b id="best">0</b></div>
-            </div>
           </div>
-          <div class="buttons">
-            <button id="btnHard">Hard Drop</button>
-          </div>
+          
           <div class="tag" id="comboTag"></div>
         </div>
         <div class="panel"><div class="next-hold">
@@ -62,7 +56,7 @@
             </div>
           </div>
           <h3>Steuerung</h3>
-          <p>Nutze die Bildschirm-Buttons (◀︎/▶︎/⟳/HOLD/Soft/HARD/Pause/Neu) auf Mobilgeräten.</p>
+          <p>Nutze die Bildschirm-Buttons (◀︎/▶︎/⟳/HOLD/Soft/Pause/Neu) auf Mobilgeräten.</p>
           <p>Auf Desktop funktionieren zusätzlich folgende Tasten:</p>
           <ul>
             <li><kbd>←</kbd>/<kbd>→</kbd>: bewegen</li>
@@ -95,7 +89,6 @@
     <button id="mRight">▶︎</button>
     <button id="mHold">HOLD</button>
     <button id="mSoft">Soft ↓</button>
-    <button id="mHard">HARD ⤓</button>
     <button id="mPause">Pause</button>
     <button id="mStart">Neu</button>
   </div>

--- a/tetris.js
+++ b/tetris.js
@@ -294,12 +294,8 @@ document.addEventListener('contextmenu', e => e.preventDefault());
   }
 
   function updateSide(){
-    const scoreEl = document.getElementById('score');
-    if(scoreEl) scoreEl.textContent = score;
     const scoreTop = document.getElementById('topScore');
     if(scoreTop) scoreTop.textContent = `Score: ${score}`;
-    const bestEl = document.getElementById('best');
-    if(bestEl) bestEl.textContent = best;
     const bestTop = document.getElementById('topBest');
     if(bestTop) bestTop.textContent = `Best: ${best}`;
     if(nctx) drawMini(nctx, queue[0]);
@@ -537,7 +533,6 @@ document.addEventListener('contextmenu', e => e.preventDefault());
   const modeSelect = document.getElementById('modeSelect');
   if(modeSelect){ modeSelect.addEventListener('change', ()=>{ reset(); update(); }); }
   document.getElementById('btnPause').addEventListener('click', ()=>{ if(running){ setPaused(!paused); }});
-  document.getElementById('btnHard').addEventListener('click', ()=>{ if(running&&!paused) hardDrop(); });
   const btnResetHS = document.getElementById('btnResetHS');
   if(btnResetHS){
     btnResetHS.addEventListener('click', ()=>{


### PR DESCRIPTION
## Summary
- Remove duplicate Score/Best panel beneath game board and mobile Hard Drop button.
- Adjust UI text to reflect removal of Hard Drop controls.
- Clean up JavaScript: update only top score/best display and drop unused Hard Drop event listener.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a08f19d704832b93b7bc2b9be3f76b