### PR TITLE
Remove unused level overlay elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,11 +112,9 @@
   <div id="overlay" aria-hidden="true">
     <div class="overlay-card" role="dialog" aria-modal="true" aria-labelledby="ovTitle">
       <h2 id="ovTitle">Game Over</h2>
-      <p class="tag">Gut gespielt – weiter geht's?</p>
       <div class="stats" style="margin-top:8px">
         <div class="stat">Score<b id="ovScore">0</b></div>
         <div class="stat">Lines<b id="ovLines">0</b></div>
-        <div class="stat">Level<b id="ovLevel">0</b></div>
         <div class="stat">Best<b id="ovBest">0</b></div>
       </div>
       <div class="buttons" style="justify-content:center;margin-top:14px">

--- a/tetris.js
+++ b/tetris.js
@@ -154,11 +154,10 @@ document.addEventListener('contextmenu', e => e.preventDefault());
 
   // ==== Overlay helpers
   const overlay = () => document.getElementById('overlay');
-  function showOverlay(vals){
-    document.getElementById('ovScore').textContent = vals.score;
-    document.getElementById('ovLines').textContent = vals.lines;
-    document.getElementById('ovLevel').textContent = vals.level;
-    document.getElementById('ovBest').textContent = vals.best;
+  function showOverlay({score, lines, best}){
+    document.getElementById('ovScore').textContent = score;
+    document.getElementById('ovLines').textContent = lines;
+    document.getElementById('ovBest').textContent = best;
     overlay().classList.add('show');
   }
   function hideOverlay(){ overlay().classList.remove('show'); }
@@ -445,7 +444,7 @@ document.addEventListener('contextmenu', e => e.preventDefault());
     addHS({ name, score, lines, date: new Date().toISOString().slice(0,10) }, mode);
     renderHS(mode);
     updateSide();
-    showOverlay({score, lines, level, best});
+    showOverlay({score, lines, best});
     sfx.gameover();
   }
 


### PR DESCRIPTION
## Summary
- Remove level display and tagline from game over overlay
- Drop ovLevel references and update showOverlay parameters

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a099efc868832ba2e8d9a47c3c4478