### PR TITLE
Remove tagline from index heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,6 @@
   <div class="wrap">
     <div>
       <h1>🧱 Tetris</h1>
-      <p class="tag">Vanilla JavaScript • Canvas • Level/Score/Lines • Soft/Hard Drop • Pause • 7‑Bag RNG</p>
       <div class="controls top-controls">
         <button id="btnMenu">Menü</button>
         <button id="btnPlayer">Spieler</button>


### PR DESCRIPTION
## Summary
- remove descriptive tagline from under the Tetris title so the menu sits directly beneath the heading

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a099ed677c832b9468e95c9318e644