### PR TITLE
Sanitize highscore rendering to prevent XSS

### DIFF
--- a/tetris.js
+++ b/tetris.js
@@ -111,9 +111,22 @@ document.addEventListener('contextmenu', e => e.preventDefault());
   const bestKey = m => `${BEST_KEY_BASE}_${m}`;
   function loadHS(m){ try{ return JSON.parse(localStorage.getItem(hsKey(m))) || []; }catch(e){ return []; } }
   function saveHS(list,m){ localStorage.setItem(hsKey(m), JSON.stringify(list)); }
+  function sanitizeName(str){
+    return str.replace(/<[^>]*>/g, '').trim();
+  }
+  function sanitizeHS(list,m){
+    let changed=false;
+    const cleaned=list.map(e=>{
+      const name=sanitizeName(e.name||'');
+      if(name!==e.name) changed=true;
+      return {...e, name};
+    });
+    if(changed) saveHS(cleaned,m);
+    return cleaned;
+  }
   function addHS(entry,m){
-    const list = loadHS(m);
-    list.push(entry);
+    const list = sanitizeHS(loadHS(m),m);
+    list.push({...entry, name: sanitizeName(entry.name)});
     list.sort((a,b)=>b.score - a.score || b.lines - a.lines);
     const top10 = list.slice(0,10);
     saveHS(top10,m);
@@ -122,10 +135,23 @@ document.addEventListener('contextmenu', e => e.preventDefault());
   function renderHS(m=mode){
     const tbody = document.querySelector('#hsTable tbody');
     if(!tbody) return;
-    const list = loadHS(m);
-    tbody.innerHTML = list.map((e,i)=>
-      `<tr><td>${i+1}</td><td>${e.name}</td><td>${e.score}</td><td>${e.lines}</td><td>${e.date}</td></tr>`
-    ).join('');
+    const list = sanitizeHS(loadHS(m),m);
+    while(tbody.firstChild) tbody.removeChild(tbody.firstChild);
+    list.forEach((e,i)=>{
+      const tr=document.createElement('tr');
+      const tdRank=document.createElement('td');
+      tdRank.textContent=String(i+1);
+      const tdName=document.createElement('td');
+      tdName.textContent=e.name;
+      const tdScore=document.createElement('td');
+      tdScore.textContent=String(e.score);
+      const tdLines=document.createElement('td');
+      tdLines.textContent=String(e.lines);
+      const tdDate=document.createElement('td');
+      tdDate.textContent=e.date;
+      tr.append(tdRank,tdName,tdScore,tdLines,tdDate);
+      tbody.appendChild(tr);
+    });
     const label=document.getElementById('hsModeLabel');
     if(label) label.textContent = (m===MODE_ULTRA? 'Ultra' : 'Classic');
   }
@@ -447,7 +473,7 @@ document.addEventListener('contextmenu', e => e.preventDefault());
     setPaused(false);
     best = Math.max(best, score);
     localStorage.setItem(bestKey(mode), best);
-    const name = playerName.trim() || 'Player';
+    const name = sanitizeName(playerName.trim() || 'Player');
     addHS({ name, score, lines, date: new Date().toISOString().slice(0,10) }, mode);
     renderHS(mode);
     updateSide();


### PR DESCRIPTION
## Summary
- Render highscore table using DOM nodes instead of innerHTML
- Sanitize player names and stored highscores to strip HTML
- Clean up existing highscore entries with unsafe content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a09c86e978832b897f4b30ff3a8ba2