### PR TITLE
feat: implement Fisher-Yates shuffle

### DIFF
--- a/test/refillBag.test.js
+++ b/test/refillBag.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+test('refillBag shuffles pieces uniformly', () => {
+  const code = fs.readFileSync(path.join(__dirname, '..', 'tetris.js'), 'utf8');
+  const match = code.match(/function\s+refillBag\(\)\{([\s\S]*?)\n  \}/);
+  assert.ok(match, 'refillBag function not found');
+  const context = { bag: [] };
+  vm.createContext(context);
+  vm.runInContext(`function refillBag(){${match[1]}}`, context);
+
+  const types = ['I', 'J', 'L', 'O', 'S', 'T', 'Z'];
+  const counts = Array.from({ length: types.length }, () => Object.fromEntries(types.map(t => [t, 0])));
+  const iterations = 70000;
+  for (let i = 0; i < iterations; i++) {
+    context.bag = [];
+    vm.runInContext('refillBag()', context);
+    const arr = context.bag;
+    for (let idx = 0; idx < types.length; idx++) {
+      counts[idx][arr[idx]]++;
+    }
+  }
+  const expected = iterations / types.length;
+  const tolerance = expected * 0.05; // 5%
+  for (let pos = 0; pos < types.length; pos++) {
+    for (const type of types) {
+      assert.ok(Math.abs(counts[pos][type] - expected) < tolerance,
+        `pos ${pos} type ${type} count ${counts[pos][type]} out of range`);
+    }
+  }
+});

--- a/tetris.js
+++ b/tetris.js
@@ -226,8 +226,11 @@ document.addEventListener('contextmenu', e => e.preventDefault());
 
   function refillBag(){
     const types=['I','J','L','O','S','T','Z'];
-    const shuffled = [...types].sort(()=>Math.random()-0.5);
-    bag.push(...shuffled);
+    for(let i=types.length-1;i>0;i--){
+      const j=Math.floor(Math.random()*(i+1));
+      [types[i],types[j]]=[types[j],types[i]];
+    }
+    bag.push(...types);
   }
 
   function pullNext(){


### PR DESCRIPTION
## Summary
- replace array sort shuffle with Fisher-Yates algorithm in refillBag for unbiased piece ordering
- add statistical test ensuring uniform distribution of pieces across bag positions

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68a09d8c8de8832bb57052f285ab18fb