### PR TITLE
Cache additional Tetris assets for offline start

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,8 +1,11 @@
-const CACHE = 'tetris-cache-v2';
+const CACHE = 'tetris-cache-v3';
 const ASSETS = [
   './',
   './index.html',
   './manifest.json',
+  './tetris.js',
+  './styles.css',
+  './fonts/PressStart2P.woff2',
   './icons/icon-180.png',
   './icons/icon-192.png',
   './icons/icon-512.png'
@@ -12,10 +15,14 @@ self.addEventListener('install', (e) => {
   e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)));
   self.skipWaiting();
 });
+
 self.addEventListener('activate', (e) => {
-  e.waitUntil(caches.keys().then(keys => Promise.all(keys.map(k => k !== CACHE ? caches.delete(k) : null))));
+  e.waitUntil(caches.keys().then(keys => Promise.all(
+    keys.map(k => (k !== CACHE ? caches.delete(k) : null))
+  )));
   self.clients.claim();
 });
+
 self.addEventListener('fetch', (e) => {
   e.respondWith(
     caches.match(e.request).then(r => r || fetch(e.request).then(resp => {
@@ -25,3 +32,4 @@ self.addEventListener('fetch', (e) => {
     }).catch(() => caches.match('./index.html')))
   );
 });
+


### PR DESCRIPTION
## Summary
- cache `tetris.js`, `styles.css` and font in the service worker
- bump service worker cache version to invalidate old caches

## Testing
- `node --test test/refillBag.test.js`
- Manual offline start test not run: `npm install playwright` failed with 403

------
https://chatgpt.com/codex/tasks/task_e_68a09eccfd38832b86207ed1e14abebc