### PR TITLE
Refactor Tetris into ES modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,6 +123,6 @@
     </div>
   </div>
 
-  <script src="tetris.js"></script>
+  <script type="module" src="src/main.js"></script>
 </body>
 </html>

--- a/src/audio.js
+++ b/src/audio.js
@@ -1,0 +1,26 @@
+export function createSfx(settings){
+  let actx = null;
+  function ensureAudio(){
+    if(!settings.sound) return null;
+    if(!actx){
+      try{ actx = new (window.AudioContext||window.webkitAudioContext)(); }catch{}
+    }
+    return actx;
+  }
+  function beep(freq=440, dur=0.06, type='sine', gain=0.05){
+    const ac = ensureAudio(); if(!ac) return;
+    const o = ac.createOscillator(); const g = ac.createGain();
+    o.type = type; o.frequency.value=freq; g.gain.value=gain;
+    o.connect(g); g.connect(ac.destination);
+    const t = ac.currentTime; o.start(t); o.stop(t+dur);
+  }
+  return {
+    move: ()=>beep(300,0.03,'square',0.025),
+    rotate: ()=>beep(520,0.04,'sine',0.035),
+    lock: ()=>beep(220,0.06,'triangle',0.05),
+    clear: ()=>{ beep(700,0.05,'sine',0.05); setTimeout(()=>beep(920,0.05,'sine',0.05),40); },
+    level: ()=>{ beep(500,0.08,'triangle',0.06); setTimeout(()=>beep(750,0.08,'triangle',0.06),70); },
+    hard: ()=>beep(180,0.05,'square',0.06),
+    gameover: ()=>{ beep(200,0.08,'sawtooth',0.07); setTimeout(()=>beep(150,0.12,'sawtooth',0.06),90); }
+  };
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,75 @@
+export const THEME_KEY = 'tetris_theme';
+export const PLAYER_KEY = 'tetris_player';
+
+export const COLS = 10;
+export const ROWS = 20;
+export const SIZE = 30;
+export const FALL_BASE_MS = 800; // Basisintervall (Level 1)
+export const LINES_PER_LEVEL = 10;
+export const SCORE_LINE = [0,100,300,500,800];
+export const SETTINGS_KEY = 'tetris_settings_v1';
+export const MODE_CLASSIC = 'classic';
+export const MODE_ULTRA = 'ultra';
+export const ULTRA_SECONDS = 120;
+
+export const COLOR_SETS = {
+  standard: {
+    0: '#000000', // leer (wird nicht gemalt)
+    I: '#4fd1ff', J: '#4c6ef5', L: '#f59f00', O: '#fcc419',
+    S: '#51cf66', T: '#be4bdb', Z: '#ff6b6b'
+  },
+  accessible: {
+    0: '#000000',
+    I: '#0072b2', J: '#56b4e9', L: '#e69f00', O: '#f0e442',
+    S: '#009e73', T: '#cc79a7', Z: '#d55e00'
+  }
+};
+
+// Tetromino-Matrizen (4×4 Frames) – im Uhrzeigersinn rotierend
+export const SHAPES = {
+  I: [
+    [[0,0,0,0],[1,1,1,1],[0,0,0,0],[0,0,0,0]],
+    [[0,0,1,0],[0,0,1,0],[0,0,1,0],[0,0,1,0]],
+    [[0,0,0,0],[0,0,0,0],[1,1,1,1],[0,0,0,0]],
+    [[0,1,0,0],[0,1,0,0],[0,1,0,0],[0,1,0,0]]
+  ],
+  J: [
+    [[1,0,0],[1,1,1],[0,0,0]],
+    [[0,1,1],[0,1,0],[0,1,0]],
+    [[0,0,0],[1,1,1],[0,0,1]],
+    [[0,1,0],[0,1,0],[1,1,0]]
+  ],
+  L: [
+    [[0,0,1],[1,1,1],[0,0,0]],
+    [[0,1,0],[0,1,0],[0,1,1]],
+    [[0,0,0],[1,1,1],[1,0,0]],
+    [[1,1,0],[0,1,0],[0,1,0]]
+  ],
+  O: [
+    [[1,1],[1,1]],
+    [[1,1],[1,1]],
+    [[1,1],[1,1]],
+    [[1,1],[1,1]]
+  ],
+  S: [
+    [[0,1,1],[1,1,0],[0,0,0]],
+    [[0,1,0],[0,1,1],[0,0,1]],
+    [[0,0,0],[0,1,1],[1,1,0]],
+    [[1,0,0],[1,1,0],[0,1,0]]
+  ],
+  T: [
+    [[0,1,0],[1,1,1],[0,0,0]],
+    [[0,1,0],[0,1,1],[0,1,0]],
+    [[0,0,0],[1,1,1],[0,1,0]],
+    [[0,1,0],[1,1,0],[0,1,0]]
+  ],
+  Z: [
+    [[1,1,0],[0,1,1],[0,0,0]],
+    [[0,0,1],[0,1,1],[0,1,0]],
+    [[0,0,0],[1,1,0],[0,1,1]],
+    [[0,1,0],[1,1,0],[1,0,0]]
+  ]
+};
+
+export const HS_KEY_BASE = 'tetris_highscores_v1';
+export const BEST_KEY_BASE = 'tetris_best';

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,15 @@
+import { SHAPES, COLS } from './constants.js';
+
+export function newPiece(type){
+  const shape = SHAPES[type];
+  return {type, rot:0, x: Math.floor(COLS/2)-2, y: -2, shape};
+}
+
+export function refillBag(bag){
+  const types=['I','J','L','O','S','T','Z'];
+  for(let i=types.length-1;i>0;i--){
+    const j=Math.floor(Math.random()*(i+1));
+    [types[i],types[j]]=[types[j],types[i]];
+  }
+  bag.push(...types);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,12 @@
+import { initUI } from './ui.js';
+import { initGame } from './game.js';
+
+initUI();
+initGame();
+
+// Register external Service Worker (works on Netlify & GitHub Pages)
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('sw.js', { scope: './' }).catch(()=>{});
+  });
+}

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,0 +1,38 @@
+import { THEME_KEY, PLAYER_KEY } from './constants.js';
+
+export function initUI(){
+  if (localStorage.getItem(THEME_KEY) === 'light') {
+    document.body.classList.add('theme-light');
+  }
+  const btnTheme = document.getElementById('themeToggle');
+  if (btnTheme) {
+    btnTheme.addEventListener('click', () => {
+      document.body.classList.toggle('theme-light');
+      localStorage.setItem(
+        THEME_KEY,
+        document.body.classList.contains('theme-light') ? 'light' : 'dark'
+      );
+    });
+  }
+
+  let playerName = localStorage.getItem(PLAYER_KEY) || 'Player';
+  if (localStorage.getItem(PLAYER_KEY) === null) {
+    const name = prompt('Bitte Spielername eingeben:');
+    if (name !== null) {
+      playerName = name.trim() || 'Player';
+      localStorage.setItem(PLAYER_KEY, playerName);
+    }
+  }
+  const btnPlayer = document.getElementById('btnPlayer');
+  if (btnPlayer) {
+    btnPlayer.addEventListener('click', () => {
+      const name = prompt('Spielername:', playerName);
+      if (name !== null) {
+        playerName = name.trim() || 'Player';
+        localStorage.setItem(PLAYER_KEY, playerName);
+      }
+    });
+  }
+
+  document.addEventListener('contextmenu', e => e.preventDefault());
+}

--- a/test/refillBag.test.js
+++ b/test/refillBag.test.js
@@ -1,29 +1,17 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import fs from 'node:fs';
-import path from 'node:path';
-import vm from 'node:vm';
-import { fileURLToPath } from 'node:url';
+import { refillBag } from '../src/helpers.js';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const types = ['I', 'J', 'L', 'O', 'S', 'T', 'Z'];
 
 test('refillBag shuffles pieces uniformly', () => {
-  const code = fs.readFileSync(path.join(__dirname, '..', 'tetris.js'), 'utf8');
-  const match = code.match(/function\s+refillBag\(\)\{([\s\S]*?)\n  \}/);
-  assert.ok(match, 'refillBag function not found');
-  const context = { bag: [] };
-  vm.createContext(context);
-  vm.runInContext(`function refillBag(){${match[1]}}`, context);
-
-  const types = ['I', 'J', 'L', 'O', 'S', 'T', 'Z'];
   const counts = Array.from({ length: types.length }, () => Object.fromEntries(types.map(t => [t, 0])));
   const iterations = 70000;
   for (let i = 0; i < iterations; i++) {
-    context.bag = [];
-    vm.runInContext('refillBag()', context);
-    const arr = context.bag;
+    const bag = [];
+    refillBag(bag);
     for (let idx = 0; idx < types.length; idx++) {
-      counts[idx][arr[idx]]++;
+      counts[idx][bag[idx]]++;
     }
   }
   const expected = iterations / types.length;


### PR DESCRIPTION
## Summary
- Move game logic into `src/` and break up original `tetris.js` into `game.js`, `ui.js`, `audio.js`, `helpers.js`, and `constants.js`.
- Switch to ES module architecture with a `main.js` bootstrap and update `index.html`.
- Update tests to use new helper module.

## Testing
- `node --test`
- Attempted `node -e import('playwright')` but Playwright was unavailable

------
https://chatgpt.com/codex/tasks/task_e_68a09ed8ded8832bb77b396e8ad6b088