### PR TITLE
Add single-rotation game mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
         <label>Modus:
           <select id="modeSelect" class="input">
             <option value="classic">Classic (endlos)</option>
+            <option value="classic_once">Classic – 1 Drehung</option>
             <option value="ultra">Ultra – 2 Minuten</option>
           </select>
         </label>

--- a/src/constants.js
+++ b/src/constants.js
@@ -10,6 +10,7 @@ export const SCORE_LINE = [0,100,300,500,800];
 export const SETTINGS_KEY = 'tetris_settings_v1';
 export const MODE_CLASSIC = 'classic';
 export const MODE_ULTRA = 'ultra';
+export const MODE_CLASSIC_ONCE = 'classic_once';
 export const ULTRA_SECONDS = 120;
 
 export const COLOR_SETS = {

--- a/src/game.js
+++ b/src/game.js
@@ -1,6 +1,6 @@
 import {
   COLS, ROWS, SIZE, FALL_BASE_MS, LINES_PER_LEVEL, SCORE_LINE,
-  SETTINGS_KEY, MODE_CLASSIC, MODE_ULTRA, ULTRA_SECONDS, COLOR_SETS,
+  SETTINGS_KEY, MODE_CLASSIC, MODE_ULTRA, MODE_CLASSIC_ONCE, ULTRA_SECONDS, COLOR_SETS,
   HS_KEY_BASE, BEST_KEY_BASE, PLAYER_KEY
 } from './constants.js';
 import { newPiece, refillBag } from './helpers.js';
@@ -58,7 +58,12 @@ export function initGame(){
       tbody.appendChild(tr);
     });
     const label=document.getElementById('hsModeLabel');
-    if(label) label.textContent = (m===MODE_ULTRA? 'Ultra' : 'Classic');
+    if(label){
+      label.textContent =
+        m===MODE_ULTRA ? 'Ultra' :
+        m===MODE_CLASSIC_ONCE ? 'Classic – 1 Drehung' :
+        'Classic';
+    }
   }
 
   // ==== Settings (persist)
@@ -370,7 +375,15 @@ export function initGame(){
       }
       case 'ArrowDown': softDrop(); break;
       case 'ArrowUp':
-      case 'KeyW': cur = rotate(board, cur); sfx.rotate(); break;
+      case 'KeyW': {
+        if(mode !== MODE_CLASSIC_ONCE || !cur.rotated){
+          const r = rotate(board, cur);
+          if(r !== cur && mode === MODE_CLASSIC_ONCE) r.rotated = true;
+          cur = r;
+          sfx.rotate();
+        }
+        break;
+      }
       case 'Space': hardDrop(); break;
     }
   }, {passive:false});
@@ -426,7 +439,14 @@ export function initGame(){
   const touchMap = {
     mLeft:()=>{const p={...cur,x:cur.x-1}; if(!collides(board, p)) {cur.x--; sfx.move();}},
     mRight:()=>{const p={...cur,x:cur.x+1}; if(!collides(board, p)) {cur.x++; sfx.move();}},
-    mRotate:()=>{cur=rotate(board, cur); sfx.rotate();},
+    mRotate:()=>{
+      if(mode !== MODE_CLASSIC_ONCE || !cur.rotated){
+        const r = rotate(board, cur);
+        if(r !== cur && mode === MODE_CLASSIC_ONCE) r.rotated = true;
+        cur = r;
+        sfx.rotate();
+      }
+    },
     mSoft:()=>softDrop(),
     mHard:()=>hardDrop(),
     mPause:()=>{ if(running){ setPaused(!paused); } },

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,7 +2,7 @@ import { SHAPES, COLS } from './constants.js';
 
 export function newPiece(type){
   const shape = SHAPES[type];
-  return {type, rot:0, x: Math.floor(COLS/2)-2, y: -2, shape};
+  return {type, rot:0, x: Math.floor(COLS/2)-2, y: -2, shape, rotated:false};
 }
 
 export function refillBag(bag){

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,0 +1,8 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { newPiece } from '../src/helpers.js';
+
+test('newPiece initializes with rotation unused', () => {
+  const p = newPiece('T');
+  assert.equal(p.rotated, false);
+});


### PR DESCRIPTION
## Summary
- add `Classic – 1 Drehung` mode that allows rotating each piece only once
- track rotation usage per piece and block additional rotations in this mode
- update UI/options and highscore label for the new mode
- add helper test for rotation flag initialization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0c5ed88a8832b8fad7dac1b62afd6