### PR TITLE
Show next pieces beneath board

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,10 +42,10 @@
               <canvas id="game" width="300" height="600" aria-label="Tetris Board"></canvas>
               <div id="pauseOverlay" aria-hidden="true">PAUSE</div>
             </div>
-            <div class="next" style="display:flex;flex-direction:column;gap:8px">
-              <div class="mini"><canvas id="next1" width="96" height="80" aria-label="Nächster Stein 1"></canvas></div>
-              <div class="mini"><canvas id="next2" width="96" height="80" aria-label="Nächster Stein 2"></canvas></div>
-              <div class="mini"><canvas id="next3" width="96" height="80" aria-label="Nächster Stein 3"></canvas></div>
+            <div class="next" style="display:flex;gap:8px;justify-content:center;width:100%">
+              <div class="mini"><canvas id="next1" width="64" height="64" aria-label="Nächster Stein 1"></canvas></div>
+              <div class="mini"><canvas id="next2" width="64" height="64" aria-label="Nächster Stein 2"></canvas></div>
+              <div class="mini"><canvas id="next3" width="64" height="64" aria-label="Nächster Stein 3"></canvas></div>
             </div>
           </div>
           

--- a/src/game.js
+++ b/src/game.js
@@ -162,7 +162,7 @@ export function initGame(){
     clearCanvas(ctx2);
     if(!piece) return;
     const m = piece.shape[0];
-    const size = 24;
+    const size = Math.floor(Math.min(ctx2.canvas.width, ctx2.canvas.height) / 4);
     const offX = Math.floor((ctx2.canvas.width/size - m[0].length)/2);
     const offY = Math.floor((ctx2.canvas.height/size - m.length)/2);
     for(let y=0;y<m.length;y++){

--- a/styles.css
+++ b/styles.css
@@ -31,11 +31,10 @@ html,body{height:100%;margin:0;background-color:var(--bg);background-image:linea
 h1{font-size:28px;letter-spacing:1px;margin:0 0 8px;font-family:'Press Start 2P',monospace}
 p{color:var(--muted);margin:0 0 12px}
 .grid{display:grid;grid-template-columns:320px 160px 160px;gap:16px;align-items:start}
-.game-area{display:flex;gap:16px;align-items:flex-start}
+.game-area{display:flex;flex-direction:column;gap:8px;align-items:center}
 @media (max-width:720px){
   .wrap{grid-template-columns:1fr}
   .grid{grid-template-columns:1fr}
-  .game-area{flex-direction:column;align-items:center}
   .board-wrap{max-width:90vw}
   .mobile-controls{display:grid;position:fixed;left:50%;transform:translateX(-50%);bottom:10px;width:100%;max-width:480px;background:var(--panel-bg);border:1px solid var(--panel-border);padding:8px;border-radius:12px;box-shadow:0 4px 12px rgba(0,0,0,.3);z-index:1000}
   body{padding-bottom:120px}


### PR DESCRIPTION
## Summary
- Display upcoming Tetris pieces horizontally below the playfield with smaller canvases.
- Adapt preview drawing to scale with canvas size.
- Stack board and preview vertically and center them.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a17d5c7ce8832b8cb82ff04a3d677f