### PR TITLE
Enable playable Snake mode with instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,20 +160,24 @@
     </dialog>
   </div>
 
-  <div id="snakeWrap" class="wrap" style="display:none">
-    <div>
-      <h1>🐍 Snake</h1>
-      <div class="controls top-controls">
-        <button id="snakeStart"><span class="material-icons">play_arrow</span> Start/Neu</button>
-      </div>
-      <div class="panel" style="margin-top:16px;text-align:center">
-        <canvas id="snakeCanvas" width="300" height="300" aria-label="Snake Board"></canvas>
-        <div class="controls" style="justify-content:center;margin-top:8px">
-          <span class="timer" id="snakeScoreLabel">Score: <span id="snakeScore">0</span></span>
+    <div id="snakeWrap" class="wrap" style="display:none">
+      <div>
+        <h1>🐍 Snake</h1>
+        <div class="controls top-controls">
+          <button id="snakeStart"><span class="material-icons">play_arrow</span> Start/Neu</button>
+        </div>
+        <div class="panel" style="margin-top:16px;text-align:center">
+          <canvas id="snakeCanvas" width="300" height="300" aria-label="Snake Board"></canvas>
+          <div class="controls" style="justify-content:center;margin-top:8px">
+            <span class="timer" id="snakeScoreLabel">Score: <span id="snakeScore">0</span></span>
+          </div>
+        </div>
+        <div class="panel">
+          <h3>Steuerung</h3>
+          <p>Bewege die Schlange mit den Pfeiltasten. Iss die roten Häppchen und vermeide Kollisionen mit Wänden oder dir selbst.</p>
         </div>
       </div>
     </div>
-  </div>
 
   <script type="module" src="src/main.js"></script>
 </body>

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ import { logError } from './logger.js';
 
 initUI();
 initGame();
-initSnake();
+const snakeGame = initSnake();
 
 const gameSelect = document.getElementById('gameSelect');
 const tetrisWrap = document.getElementById('tetrisWrap');
@@ -18,10 +18,12 @@ function switchGame(){
     tetrisWrap.style.display = 'none';
     snakeWrap.style.display = 'block';
     document.title = 'Snake';
+    snakeGame.start();
   }else{
     tetrisWrap.style.display = 'block';
     snakeWrap.style.display = 'none';
     document.title = 'Tetris – Vanilla JS (Einzeldatei) + Scoreboard';
+    snakeGame.stop();
   }
 }
 

--- a/src/snake.js
+++ b/src/snake.js
@@ -2,7 +2,12 @@
 export function initSnake(){
   const canvas = document.getElementById('snakeCanvas');
   const btnStart = document.getElementById('snakeStart');
-  if(!canvas || !btnStart) return;
+  if(!canvas || !btnStart){
+    return {
+      start: () => {},
+      stop: () => {}
+    };
+  }
   const ctx = canvas.getContext('2d');
   const size = 15;
   const cells = Math.floor(canvas.width / size);
@@ -86,5 +91,5 @@ export function initSnake(){
   btnStart.addEventListener('click', start);
   document.addEventListener('keydown', handleKey);
 
-  // no return value
+  return { start, stop };
 }


### PR DESCRIPTION
## Summary
- start and stop the new Snake game automatically when switching modes
- expose Snake game controls for outside use
- add basic Snake control instructions to the HTML

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1c665f624832ba9c774261e598807