### PR TITLE
Remove mobile touch control panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,15 +88,6 @@
     <div class="footer">© 2025 – Einzeldatei. Speichere diese Seite als <code>tetris.html</code> und öffne sie im Browser.</div>
     </div>
 
-    <div class="mobile-controls" aria-label="Touch Controls">
-    <button id="mLeft" aria-label="Nach links bewegen"><span class="material-icons">chevron_left</span></button>
-    <button id="mRotate" aria-label="Figur rotieren"><span class="material-icons">rotate_right</span></button>
-    <button id="mRight" aria-label="Nach rechts bewegen"><span class="material-icons">chevron_right</span></button>
-    <button id="mSoft" aria-label="Soft Drop"><span class="material-icons">arrow_downward</span></button>
-    <button id="mPause" aria-label="Pause"><span class="material-icons">pause</span></button>
-    <button id="mStart" aria-label="Neues Spiel"><span class="material-icons">replay</span></button>
-    </div>
-
   </div>
 
   <div id="snakeWrap" class="hidden">
@@ -122,10 +113,6 @@
             <p>Tippe links oder rechts auf den Bildschirm, um die Schlange 90° nach links beziehungsweise rechts zu drehen. Iss die roten Häppchen und vermeide Kollisionen mit Wänden oder dir selbst.</p>
           </div>
         </div>
-      </div>
-      <div class="mobile-controls" aria-label="Touch Controls">
-        <button id="sPause" aria-label="Pause"><span class="material-icons">pause</span></button>
-        <button id="sStart" aria-label="Neues Spiel"><span class="material-icons">replay</span></button>
       </div>
   </div>
   <div id="menuOverlay" aria-hidden="true">

--- a/src/game.js
+++ b/src/game.js
@@ -391,7 +391,7 @@ export function initGame(){
   const btnClose = document.getElementById('btnClose');
   if(btnClose){ btnClose.addEventListener('click', ()=> hideOverlay()); }
 
-  // Touch Buttons
+  // Touch actions for swipe gestures
   const touchMap = {
     mLeft:()=>{ if(paused) return; const p={...cur,x:cur.x-1}; if(!collides(board, p)) {cur.x--; sfx.move();}},
     mRight:()=>{ if(paused) return; const p={...cur,x:cur.x+1}; if(!collides(board, p)) {cur.x++; sfx.move();}},
@@ -404,30 +404,8 @@ export function initGame(){
         sfx.rotate();
       }
     },
-    mSoft:()=>{ if(paused) return; softDrop(); },
-    mHard:()=>{ if(paused) return; hardDrop(); },
-    mPause:()=>{ if(running){ setPaused(!paused); } },
-    mStart:()=>{ reset(); update(); }
+    mHard:()=>{ if(paused) return; hardDrop(); }
   };
-  Object.keys(touchMap).forEach(id=>{
-    const el=document.getElementById(id);
-    if(!el) return;
-    if(id==='mLeft' || id==='mRight') return;
-    el.addEventListener('click', touchMap[id]);
-  });
-
-  function addHoldRepeat(id, fn){
-    const el=document.getElementById(id);
-    if(!el) return;
-    let t=null, iv=null;
-    const clear=()=>{ if(t){clearTimeout(t); t=null;} if(iv){clearInterval(iv); iv=null;} };
-    const start=(e)=>{ if(paused) return; e.preventDefault(); fn(); t=setTimeout(()=>{ iv=setInterval(fn,80); },150); };
-    const end=()=>clear();
-    ['touchstart','mousedown'].forEach(evt=>el.addEventListener(evt,start));
-    ['touchend','mouseup','mouseleave','touchcancel'].forEach(evt=>el.addEventListener(evt,end));
-  }
-  addHoldRepeat('mLeft', touchMap.mLeft);
-  addHoldRepeat('mRight', touchMap.mRight);
 
   // Swipe Gestures auf dem Board
   (function(){

--- a/src/snake.js
+++ b/src/snake.js
@@ -3,8 +3,6 @@ export function initSnake(){
   const canvas = document.getElementById('snakeCanvas');
   const btnStart = document.getElementById('snakeStart');
   const btnPause = document.getElementById('snakePause');
-  const btnMobileStart = document.getElementById('sStart');
-  const btnMobilePause = document.getElementById('sPause');
   const topScoreEl = document.getElementById('snakeTopScore');
   const topBestEl = document.getElementById('snakeTopBest');
   const menuOverlay = document.getElementById('menuOverlay');
@@ -146,8 +144,6 @@ export function initSnake(){
 
   btnStart.addEventListener('click', start);
   if(btnPause) btnPause.addEventListener('click', togglePause);
-  if(btnMobileStart) btnMobileStart.addEventListener('click', start);
-  if(btnMobilePause) btnMobilePause.addEventListener('click', togglePause);
   canvas.addEventListener('touchstart', handleTouch, {passive:false});
   canvas.addEventListener('mousedown', handleTouch);
   document.addEventListener('keydown', handleKey);

--- a/styles.css
+++ b/styles.css
@@ -70,27 +70,6 @@ select.input option{background:var(--input-bg);color:var(--fg)}
 #game{width:100%;height:auto}
 #pauseOverlay{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-weight:800;font-size:48px;letter-spacing:2px;color:var(--fg);background:rgba(0,0,0,.35);opacity:0;pointer-events:none;transition:opacity .2s ease;border-radius:12px}
 #pauseOverlay.show{opacity:1}
-/* Mobile touch controls */
-.mobile-controls{display:none;grid-template-columns:repeat(4,1fr);gap:8px}
-@media (max-width:720px){
-  .mobile-controls{
-    display:grid;
-    position:fixed;
-    left:50%;
-    transform:translateX(-50%);
-    bottom:10px;
-    width:100%;
-    max-width:480px;
-    background:var(--panel-bg);
-    border:1px solid var(--panel-border);
-    padding:8px;
-    border-radius:12px;
-    box-shadow:0 4px 12px rgba(0,0,0,.3);
-    z-index:1000;
-  }
-  body{padding-bottom:120px}
-}
-.mobile-controls button{padding:16px;font-size:24px;border-radius:12px;display:flex;align-items:center;justify-content:center}
 .hidden{display:none!important}
 .timer{font-weight:700; font-size:18px; color:var(--accent)}
 [aria-label]::before,[aria-label]::after{display:none;content:none}


### PR DESCRIPTION
## Summary
- remove mobile `mobile-controls` markup for Tetris and Snake
- drop obsolete touch panel styles and button handlers
- keep swipe gestures while trimming mobile button code

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a874b26370832ba37e596668341c60