### PR TITLE
Show overlay after Snake game over

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,6 +166,21 @@
     </div>
   </div>
 
+  <!-- Snake Game Over Overlay -->
+  <div id="snakeOverlay" aria-hidden="true">
+    <div class="overlay-card" role="dialog" aria-modal="true" aria-labelledby="snakeOvTitle">
+      <h2 id="snakeOvTitle">Game Over</h2>
+      <div class="stats" style="margin-top:8px">
+        <div class="stat">Score<b id="snakeOvScore">0</b></div>
+        <div class="stat">Best<b id="snakeOvBest">0</b></div>
+      </div>
+      <div class="buttons" style="justify-content:center;margin-top:14px">
+        <button id="snakeBtnRestart">Neu starten</button>
+        <button id="snakeBtnClose">Schließen</button>
+      </div>
+    </div>
+  </div>
+
   <!-- Spielername Dialog -->
   <dialog id="playerDialog">
     <form method="dialog">

--- a/src/snake.js
+++ b/src/snake.js
@@ -6,6 +6,11 @@ export function initSnake(){
   const topScoreEl = document.getElementById('snakeTopScore');
   const topBestEl = document.getElementById('snakeTopBest');
   const menuOverlay = document.getElementById('menuOverlay');
+  const ov = document.getElementById('snakeOverlay');
+  const ovScoreEl = document.getElementById('snakeOvScore');
+  const ovBestEl = document.getElementById('snakeOvBest');
+  const btnRestart = document.getElementById('snakeBtnRestart');
+  const btnClose = document.getElementById('snakeBtnClose');
   if(!canvas || !btnStart){
     return {
       start: () => {},
@@ -28,6 +33,17 @@ export function initSnake(){
   function updateScore(){
     if(topScoreEl) topScoreEl.textContent = `Score: ${score}`;
     if(topBestEl) topBestEl.textContent = `Best: ${best}`;
+  }
+
+  function showOverlay(){
+    if(!ov) return;
+    if(ovScoreEl) ovScoreEl.textContent = String(score);
+    if(ovBestEl) ovBestEl.textContent = String(best);
+    ov.classList.add('show');
+  }
+
+  function hideOverlay(){
+    if(ov) ov.classList.remove('show');
   }
 
   function reset(){
@@ -58,7 +74,7 @@ export function initSnake(){
   function step(){
     const head = {x:snake[0].x + dir.x, y:snake[0].y + dir.y};
     if(head.x<0 || head.y<0 || head.x>=cells || head.y>=cells || snake.some(p=>p.x===head.x && p.y===head.y)){
-      stop();
+      gameOver();
       return;
     }
     snake.unshift(head);
@@ -76,6 +92,11 @@ export function initSnake(){
     draw();
   }
 
+  function gameOver(){
+    stop(false);
+    showOverlay();
+  }
+
   function start(){
     stop();
     running = true;
@@ -84,13 +105,14 @@ export function initSnake(){
     timer = setInterval(step, 100);
   }
 
-  function stop(){
+  function stop(hide=true){
     if(timer){
       clearInterval(timer);
       timer = null;
     }
     running = false;
     paused = false;
+    if(hide) hideOverlay();
   }
 
   function pause(){
@@ -147,6 +169,8 @@ export function initSnake(){
   canvas.addEventListener('touchstart', handleTouch, {passive:false});
   canvas.addEventListener('mousedown', handleTouch);
   document.addEventListener('keydown', handleKey);
+  if(btnRestart) btnRestart.addEventListener('click', start);
+  if(btnClose) btnClose.addEventListener('click', hideOverlay);
 
   function toggleMenu(){
     if(!menuOverlay) return;

--- a/styles.css
+++ b/styles.css
@@ -64,6 +64,10 @@ select.input option{background:var(--input-bg);color:var(--fg)}
 #overlay.show{opacity:1;pointer-events:auto}
 #overlay .overlay-card{background:var(--stat-bg);border:1px solid var(--stat-border);border-radius:16px;padding:20px 22px;min-width:320px;max-width:90vw;animation:pop .3s ease-out}
 #overlay h2{margin:0 0 6px;font-weight:600;letter-spacing:1px}
+#snakeOverlay{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;opacity:0;pointer-events:none;transition:opacity .25s ease;background:rgba(0,0,0,.45);backdrop-filter:blur(2px) saturate(1.1);z-index:9999}
+#snakeOverlay.show{opacity:1;pointer-events:auto}
+#snakeOverlay .overlay-card{background:var(--stat-bg);border:1px solid var(--stat-border);border-radius:16px;padding:20px 22px;min-width:320px;max-width:90vw;animation:pop .3s ease-out}
+#snakeOverlay h2{margin:0 0 6px;font-weight:600;letter-spacing:1px}
 @keyframes pop{from{transform:scale(.95);opacity:.6} to{transform:scale(1);opacity:1}}
 /* Pause Overlay */
 .board-wrap{position:relative;touch-action:none;width:100%;max-width:300px;margin:0 auto}


### PR DESCRIPTION
## Summary
- add dedicated game over overlay for Snake
- style overlay to match existing Tetris overlay
- display overlay when Snake ends and allow restart or close

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a878333ddc832badb9f1e452007b57