### PR TITLE
Add Snake highscore tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,6 +174,16 @@
         <div class="stat">Score<b id="snakeOvScore">0</b></div>
         <div class="stat">Best<b id="snakeOvBest">0</b></div>
       </div>
+      <h3 style="margin-top:12px">Highscores</h3>
+      <div class="controls">
+        <button id="snakeBtnResetHS">Highscores löschen</button>
+      </div>
+      <table class="table" id="snakeHsTable">
+        <thead>
+          <tr><th>#</th><th>Name</th><th>Score</th><th>Datum</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
       <div class="buttons" style="justify-content:center;margin-top:14px">
         <button id="snakeBtnRestart">Neu starten</button>
         <button id="snakeBtnClose">Schließen</button>

--- a/src/snake.js
+++ b/src/snake.js
@@ -1,4 +1,7 @@
 // Simple Snake game implementation
+import { PLAYER_KEY } from './constants.js';
+import { addHS, renderHS, clearHS } from './snakeHighscores.js';
+
 export function initSnake(){
   const canvas = document.getElementById('snakeCanvas');
   const btnStart = document.getElementById('snakeStart');
@@ -11,6 +14,7 @@ export function initSnake(){
   const ovBestEl = document.getElementById('snakeOvBest');
   const btnRestart = document.getElementById('snakeBtnRestart');
   const btnClose = document.getElementById('snakeBtnClose');
+  const btnResetHS = document.getElementById('snakeBtnResetHS');
   if(!canvas || !btnStart){
     return {
       start: () => {},
@@ -40,6 +44,7 @@ export function initSnake(){
     if(!ov) return;
     if(ovScoreEl) ovScoreEl.textContent = String(score);
     if(ovBestEl) ovBestEl.textContent = String(best);
+    renderHS();
     ov.classList.add('show');
   }
 
@@ -97,6 +102,8 @@ export function initSnake(){
 
   function gameOver(){
     stop(false);
+    const name = localStorage.getItem(PLAYER_KEY) || 'Player';
+    addHS({ name, score, date: new Date().toLocaleDateString() });
     showOverlay();
   }
 
@@ -181,6 +188,15 @@ export function initSnake(){
   document.addEventListener('keydown', handleKey);
   if(btnRestart) btnRestart.addEventListener('click', start);
   if(btnClose) btnClose.addEventListener('click', hideOverlay);
+  if(btnResetHS){
+    btnResetHS.addEventListener('click', () => {
+      clearHS();
+      localStorage.removeItem('snakeBest');
+      best = 0;
+      updateScore();
+      renderHS();
+    });
+  }
 
   function toggleMenu(){
     if(!menuOverlay) return;

--- a/src/snakeHighscores.js
+++ b/src/snakeHighscores.js
@@ -1,0 +1,56 @@
+// Highscore storage and rendering for Snake
+const HS_KEY = 'snake_hs';
+
+function load(){
+  try{
+    return JSON.parse(localStorage.getItem(HS_KEY)) || [];
+  }catch{
+    return [];
+  }
+}
+
+function save(list){
+  try{
+    localStorage.setItem(HS_KEY, JSON.stringify(list));
+  }catch{}
+}
+
+export function clearHS(){
+  try{
+    localStorage.removeItem(HS_KEY);
+  }catch{}
+}
+
+function sanitizeName(str){
+  return str.replace(/<[^>]*>/g, '').trim();
+}
+
+export function addHS(entry){
+  const list = load();
+  const cleanEntry = { ...entry, name: sanitizeName(entry.name) };
+  list.push(cleanEntry);
+  list.sort((a,b) => b.score - a.score);
+  const top10 = list.slice(0,10);
+  save(top10);
+  return top10;
+}
+
+export function renderHS(){
+  const tbody = document.querySelector('#snakeHsTable tbody');
+  if(!tbody) return;
+  const list = load();
+  while(tbody.firstChild) tbody.removeChild(tbody.firstChild);
+  list.forEach((e,i)=>{
+    const tr = document.createElement('tr');
+    const tdRank = document.createElement('td');
+    tdRank.textContent = String(i+1);
+    const tdName = document.createElement('td');
+    tdName.textContent = e.name;
+    const tdScore = document.createElement('td');
+    tdScore.textContent = String(e.score);
+    const tdDate = document.createElement('td');
+    tdDate.textContent = e.date;
+    tr.append(tdRank, tdName, tdScore, tdDate);
+    tbody.appendChild(tr);
+  });
+}


### PR DESCRIPTION
## Summary
- track Snake highscores in localStorage under `snake_hs`
- save score, name and date on game over and show top ten
- display and reset Snake highscores in the game over overlay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a87a8f04c0832bb9754962dd69266c