### PR TITLE
Improve menu accessibility and centralize overlay logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,11 +115,11 @@
         </div>
       </div>
   </div>
-  <div id="menuOverlay" aria-hidden="true">
+  <div id="menuOverlay" aria-hidden="true" role="dialog" aria-modal="true">
     <button id="btnMenuClose" style="position:absolute;top:16px;right:16px">Schließen</button>
-    <div class="buttons" style="justify-content:center;margin:24px 0;">
-      <button id="tabScore">Scoreboard</button>
-      <button id="tabSettings">Einstellungen</button>
+    <div class="buttons" role="tablist" style="justify-content:center;margin:24px 0;">
+      <button id="tabScore" role="tab" aria-controls="scorePanel">Scoreboard</button>
+      <button id="tabSettings" role="tab" aria-controls="settingsPanel">Einstellungen</button>
     </div>
     <div class="panel" id="scorePanel" style="margin-top:16px;">
       <h3>Scoreboard – <span id="hsModeLabel">Classic</span></h3>

--- a/src/game.js
+++ b/src/game.js
@@ -17,6 +17,7 @@ import { createSfx } from './audio.js';
 import { collides, clearLines as clearBoardLines, rotate, getDropY } from './logic.js';
 import { addHS, renderHS, sanitizeName, bestKey } from './highscores.js';
 import { loadSettings, saveSettings, applyPalette } from './settings.js';
+import { toggleMenuOverlay } from './menu.js';
 
 export function initGame(){
   // ==== Settings
@@ -311,7 +312,7 @@ export function initGame(){
 
     const mOverlay = document.getElementById('menuOverlay');
     if(mOverlay && mOverlay.classList.contains('show')){
-      if(e.code==='Escape'){ e.preventDefault(); toggleMenu(); }
+      if(e.code==='Escape'){ e.preventDefault(); toggleMenuOverlay(); }
       return;
     }
 
@@ -346,32 +347,19 @@ export function initGame(){
   }, {passive:false});
 
   // ==== UI Buttons
-  const menuOverlay = document.getElementById('menuOverlay');
   let menuPrevPaused = false;
-  function toggleMenu(){
-    const wrap = document.getElementById('tetrisWrap');
-    if(wrap && wrap.classList.contains('hidden')) return;
-    const show = !menuOverlay.classList.contains('show');
-    menuOverlay.classList.toggle('show', show);
-    menuOverlay.setAttribute('aria-hidden', String(!show));
+  document.querySelectorAll('#btnMenu').forEach(btn => btn.addEventListener('click', () => {
+    toggleMenuOverlay();
+  }));
+  document.addEventListener('menuToggle', e => {
+    const show = e.detail.show;
     if(show){
       menuPrevPaused = paused;
       setPaused(true);
     } else {
       setPaused(menuPrevPaused);
     }
-  }
-  document.querySelectorAll('#btnMenu').forEach(btn => btn.addEventListener('click', toggleMenu));
-  const btnMenuClose = document.getElementById('btnMenuClose');
-  if(btnMenuClose){ btnMenuClose.addEventListener('click', toggleMenu); }
-  const tabScore = document.getElementById('tabScore');
-  const tabSettings = document.getElementById('tabSettings');
-  const scorePanel = document.getElementById('scorePanel');
-  const settingsPanel = document.getElementById('settingsPanel');
-  if(tabScore && tabSettings){
-    tabScore.addEventListener('click', ()=>{ scorePanel.style.display='block'; settingsPanel.style.display='none'; });
-    tabSettings.addEventListener('click', ()=>{ scorePanel.style.display='none'; settingsPanel.style.display='block'; });
-  }
+  });
   const btnStart = document.getElementById('btnStart');
   if(btnStart){ btnStart.addEventListener('click', e=>{ e.preventDefault(); reset(); update(); }); }
   const modeSelect = document.getElementById('modeSelect');

--- a/src/main.js
+++ b/src/main.js
@@ -2,9 +2,11 @@
 import { initUI } from './ui.js';
 import { initGame } from './game.js';
 import { initSnake } from './snake.js';
+import { initMenu, toggleMenuOverlay } from './menu.js';
 import { logError } from './logger.js';
 
 initUI();
+initMenu();
 initGame();
 const snakeGame = initSnake();
 
@@ -15,9 +17,8 @@ const menuOverlay = document.getElementById('menuOverlay');
 
 function switchGame(){
   if(!gameSelect || !tetrisWrap || !snakeWrap) return;
-  if(menuOverlay){
-    menuOverlay.classList.remove('show');
-    menuOverlay.setAttribute('aria-hidden', 'true');
+  if(menuOverlay && menuOverlay.classList.contains('show')){
+    toggleMenuOverlay();
   }
   if(gameSelect.value === 'snake'){
     tetrisWrap.classList.add('hidden');

--- a/src/menu.js
+++ b/src/menu.js
@@ -1,0 +1,104 @@
+// Centralized menu overlay logic
+let overlay;
+let btnClose;
+let lastFocused = null;
+let tabButtons = [];
+let panels = {};
+const TAB_KEY = 'menuTab';
+
+export function initMenu(){
+  overlay = document.getElementById('menuOverlay');
+  if(!overlay) return;
+  btnClose = document.getElementById('btnMenuClose');
+  tabButtons = [document.getElementById('tabScore'), document.getElementById('tabSettings')].filter(Boolean);
+  panels = {
+    score: document.getElementById('scorePanel'),
+    settings: document.getElementById('settingsPanel')
+  };
+
+  // Restore last active tab
+  const saved = localStorage.getItem(TAB_KEY);
+  const defaultTab = saved === 'settings' ? tabButtons[1] : tabButtons[0];
+  if(defaultTab) activateTab(defaultTab);
+
+  // Attach handlers for tabs
+  tabButtons.forEach(btn => {
+    btn.addEventListener('click', () => activateTab(btn));
+    btn.addEventListener('keydown', handleTabKey);
+  });
+
+  // Close button
+  if(btnClose){
+    btnClose.addEventListener('click', toggleMenuOverlay);
+  }
+
+  // Trap focus & ESC
+  overlay.addEventListener('keydown', e => {
+    if(e.key === 'Tab'){
+      trapFocus(e);
+    } else if(e.key === 'Escape'){
+      e.preventDefault();
+      toggleMenuOverlay();
+    }
+  });
+}
+
+export function toggleMenuOverlay(){
+  if(!overlay) return false;
+  const show = !overlay.classList.contains('show');
+  overlay.classList.toggle('show', show);
+  overlay.setAttribute('aria-hidden', String(!show));
+  if(show){
+    lastFocused = document.activeElement;
+    setTimeout(() => btnClose && btnClose.focus(), 0);
+  } else if(lastFocused){
+    lastFocused.focus();
+  }
+  document.dispatchEvent(new CustomEvent('menuToggle', { detail: { show } }));
+  return show;
+}
+
+function activateTab(btn){
+  const isScore = btn === tabButtons[0];
+  tabButtons.forEach((b,i) => {
+    const selected = b === btn;
+    b.classList.toggle('active', selected);
+    b.setAttribute('aria-selected', String(selected));
+    const panel = i===0 ? panels.score : panels.settings;
+    if(panel) panel.style.display = selected ? 'block' : 'none';
+  });
+  localStorage.setItem(TAB_KEY, isScore ? 'score' : 'settings');
+}
+
+function handleTabKey(e){
+  const idx = tabButtons.indexOf(e.currentTarget);
+  if(e.key === 'ArrowRight' || e.code === 'ArrowRight'){
+    e.preventDefault();
+    const next = tabButtons[(idx+1)%tabButtons.length];
+    next.focus();
+    activateTab(next);
+  } else if(e.key === 'ArrowLeft' || e.code === 'ArrowLeft'){
+    e.preventDefault();
+    const prev = tabButtons[(idx-1+tabButtons.length)%tabButtons.length];
+    prev.focus();
+    activateTab(prev);
+  }
+}
+
+function trapFocus(e){
+  const focusable = overlay.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+  if(focusable.length === 0) return;
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if(e.shiftKey){
+    if(document.activeElement === first){
+      e.preventDefault();
+      last.focus();
+    }
+  } else {
+    if(document.activeElement === last){
+      e.preventDefault();
+      first.focus();
+    }
+  }
+}

--- a/src/snake.js
+++ b/src/snake.js
@@ -2,6 +2,7 @@
 import { PLAYER_KEY } from './constants.js';
 import { addHS, renderHS, clearHS } from './snakeHighscores.js';
 import { loadSettings, saveSettings } from './settings.js';
+import { toggleMenuOverlay } from './menu.js';
 
 export function initSnake(){
   const canvas = document.getElementById('snakeCanvas');
@@ -9,7 +10,6 @@ export function initSnake(){
   const btnPause = document.getElementById('snakePause');
   const topScoreEl = document.getElementById('snakeTopScore');
   const topBestEl = document.getElementById('snakeTopBest');
-  const menuOverlay = document.getElementById('menuOverlay');
   const ov = document.getElementById('snakeOverlay');
   const ovScoreEl = document.getElementById('snakeOvScore');
   const ovBestEl = document.getElementById('snakeOvBest');
@@ -240,32 +240,22 @@ export function initSnake(){
     });
   }
 
-  function toggleMenu(){
-    if(!menuOverlay) return;
-    const wrap = document.getElementById('snakeWrap');
-    if(wrap && wrap.classList.contains('hidden')) return;
-    const show = !menuOverlay.classList.contains('show');
-    menuOverlay.classList.toggle('show', show);
-    menuOverlay.setAttribute('aria-hidden', String(!show));
+  const btnMenu = document.getElementById('snakeBtnMenu');
+  if(btnMenu){
+    btnMenu.addEventListener('click', () => toggleMenuOverlay());
+  }
+  let menuPrevPaused = false;
+  document.addEventListener('menuToggle', e => {
+    const show = e.detail.show;
     if(show){
       menuPrevPaused = paused;
       pause();
-    } else {
-      if(running && !menuPrevPaused) resume();
+    } else if(running && !menuPrevPaused){
+      resume();
     }
-  }
-
-  const btnMenu = document.getElementById('snakeBtnMenu');
-  if(btnMenu){
-    btnMenu.addEventListener('click', toggleMenu);
-  }
-  const btnMenuClose = document.getElementById('btnMenuClose');
-  if(btnMenuClose){
-    btnMenuClose.addEventListener('click', toggleMenu);
-  }
-
+  });
   document.addEventListener('keydown', e => {
-    if(e.code === 'Escape') toggleMenu();
+    if(e.code === 'Escape') toggleMenuOverlay();
   });
 
   return { start, stop };

--- a/styles.css
+++ b/styles.css
@@ -59,6 +59,7 @@ select.input option{background:var(--input-bg);color:var(--fg)}
 /* Menu Overlay */
 #menuOverlay{position:fixed;inset:0;overflow-y:auto;background:rgba(0,0,0,.6);padding:24px 16px;opacity:0;pointer-events:none;transition:opacity .25s ease;z-index:9998}
 #menuOverlay.show{opacity:1;pointer-events:auto}
+#menuOverlay [role="tablist"] button.active{background:var(--button-hover-bg)}
 /* Overlay Game Over */
 #overlay{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;opacity:0;pointer-events:none;transition:opacity .25s ease;background:rgba(0,0,0,.45);backdrop-filter:blur(2px) saturate(1.1);z-index:9999}
 #overlay.show{opacity:1;pointer-events:auto}


### PR DESCRIPTION
## Summary
- add ARIA dialog roles and tablist to the global menu overlay
- centralize menu overlay handling with focus trap and tab persistence
- use new overlay module in Tetris and Snake

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a87fe04450832b88116ec3164fb21a