### PR TITLE
Fix snake module initialization error

### DIFF
--- a/src/snake.js
+++ b/src/snake.js
@@ -240,7 +240,6 @@ export function initSnake(){
     });
   }
 
-  let menuPrevPaused = false;
   document.addEventListener('menuToggle', e => {
     const show = e.detail.show;
     if(show){


### PR DESCRIPTION
## Summary
- Remove duplicate `menuPrevPaused` variable declaration that prevented snake module from loading
- Ensure menu overlay and game switching work correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8dc25aeac832b99f55acff52a70d9