### PR TITLE
feat: add supabase backend for highscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,19 @@ Verfügung.
 Wenn du eine neue Version veröffentlichst, kann der Browser wegen des Caches noch die alte laden.
 - Einmal **neu laden** (auf iPhone: Adresse antippen → Nach-unten-ziehen → neu laden).
 - Oder die Version in `sw.js` (Konstante `CACHE`) hochzählen (z. B. `tetris-cache-v3`).
-## Score-Server
-Um Highscores geräteübergreifend zu teilen, kann ein kleiner Node-Server genutzt werden.
+
+## Highscores & Backend
+### Supabase (empfohlen)
+1) In Supabase eine Tabelle `scores` mit den Spalten `id uuid primary key default gen_random_uuid()`,
+   `player text`, `mode text`, `score integer`, `lines integer`, `created_at timestamp default now()` anlegen.
+2) Die Variablen `NEXT_PUBLIC_SUPABASE_URL` und `NEXT_PUBLIC_SUPABASE_ANON_KEY` als
+   Umgebungsvariablen oder per Script-Tag (`window.NEXT_PUBLIC_SUPABASE_URL = '...';`) setzen.
+3) Das Spiel nutzt dann automatisch die Supabase-REST-API, um Highscores zu lesen und zu speichern.
+
+### Lokaler Node-Server (Fallback)
 1) `npm install` ist nicht nötig – der Server verwendet nur eingebaute Module.
 2) Start: `node server.js` (speichert Daten in `scores.json`).
-3) Das Spiel ruft die Endpunkte `/scores/<mode>` (GET/POST) auf.
+3) Das Spiel ruft die Endpunkte `/scores/<mode>` (GET/POST) auf. Für Snake wird der Modus `snake` verwendet.
 
 Viel Spaß!
 

--- a/src/highscores.js
+++ b/src/highscores.js
@@ -11,7 +11,38 @@ import { logError } from './logger.js';
 export const hsKey = m => `${HS_KEY_BASE}_${m}`;
 export const bestKey = m => `${BEST_KEY_BASE}_${m}`;
 
+const SUPABASE_URL =
+  globalThis.NEXT_PUBLIC_SUPABASE_URL ||
+  (typeof process !== 'undefined' ? process.env.NEXT_PUBLIC_SUPABASE_URL : undefined);
+const SUPABASE_KEY =
+  globalThis.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  (typeof process !== 'undefined' ? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY : undefined);
+const useSupabase = SUPABASE_URL && SUPABASE_KEY;
+
 async function loadServerHS(m) {
+  if (useSupabase) {
+    try {
+      const url = `${SUPABASE_URL}/rest/v1/scores?select=player,score,lines,created_at&mode=eq.${m}&order=score.desc,lines.desc&limit=10`;
+      const res = await fetch(url, {
+        headers: {
+          apikey: SUPABASE_KEY,
+          Authorization: `Bearer ${SUPABASE_KEY}`
+        }
+      });
+      if (res.ok) {
+        const data = await res.json();
+        return data.map(r => ({
+          name: r.player,
+          score: r.score,
+          lines: r.lines ?? 0,
+          date: (r.created_at || '').slice(0, 10)
+        }));
+      }
+    } catch (e) {
+      logError('Failed to load highscores from server', e);
+    }
+    return null;
+  }
   try {
     const res = await fetch(`/scores/${m}`);
     if (res.ok) return await res.json();
@@ -22,6 +53,30 @@ async function loadServerHS(m) {
 }
 
 async function sendServerHS(entry, m) {
+  if (useSupabase) {
+    try {
+      const res = await fetch(`${SUPABASE_URL}/rest/v1/scores`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: SUPABASE_KEY,
+          Authorization: `Bearer ${SUPABASE_KEY}`
+        },
+        body: JSON.stringify({
+          player: entry.name,
+          score: entry.score,
+          lines: entry.lines ?? 0,
+          mode: m
+        })
+      });
+      if (!res.ok) {
+        logError(`Failed to send highscore to server: ${res.status} ${res.statusText}`);
+      }
+    } catch (e) {
+      logError('Failed to send highscore to server', e);
+    }
+    return;
+  }
   try {
     const res = await fetch(`/scores/${m}`, {
       method: 'POST',

--- a/src/snakeHighscores.js
+++ b/src/snakeHighscores.js
@@ -1,6 +1,74 @@
 // Highscore storage and rendering for Snake
 import { HS_NAME_MAX_LENGTH } from './constants.js';
+import { logError } from './logger.js';
 const HS_KEY = 'snake_hs';
+
+const SUPABASE_URL =
+  globalThis.NEXT_PUBLIC_SUPABASE_URL ||
+  (typeof process !== 'undefined' ? process.env.NEXT_PUBLIC_SUPABASE_URL : undefined);
+const SUPABASE_KEY =
+  globalThis.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  (typeof process !== 'undefined' ? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY : undefined);
+const useSupabase = SUPABASE_URL && SUPABASE_KEY;
+
+async function loadServerHS(){
+  if(useSupabase){
+    try{
+      const url = `${SUPABASE_URL}/rest/v1/scores?select=player,score,created_at&mode=eq.snake&order=score.desc&limit=10`;
+      const res = await fetch(url,{
+        headers:{ apikey: SUPABASE_KEY, Authorization: `Bearer ${SUPABASE_KEY}` }
+      });
+      if(res.ok){
+        const data = await res.json();
+        return data.map(r=>({ name: r.player, score: r.score, date: (r.created_at||'').slice(0,10) }));
+      }
+    }catch(e){
+      logError('Failed to load snake highscores from server', e);
+    }
+    return null;
+  }
+  try{
+    const res = await fetch('/scores/snake');
+    if(res.ok) return await res.json();
+  }catch(e){
+    logError('Failed to load snake highscores from server', e);
+  }
+  return null;
+}
+
+async function sendServerHS(entry){
+  if(useSupabase){
+    try{
+      const res = await fetch(`${SUPABASE_URL}/rest/v1/scores`,{
+        method:'POST',
+        headers:{
+          'Content-Type':'application/json',
+          apikey: SUPABASE_KEY,
+          Authorization:`Bearer ${SUPABASE_KEY}`
+        },
+        body:JSON.stringify({ player: entry.name, mode:'snake', score: entry.score })
+      });
+      if(!res.ok){
+        logError(`Failed to send snake highscore to server: ${res.status} ${res.statusText}`);
+      }
+    }catch(e){
+      logError('Failed to send snake highscore to server', e);
+    }
+    return;
+  }
+  try{
+    const res = await fetch('/scores/snake',{
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({ ...entry, lines: entry.lines ?? 0 })
+    });
+    if(!res.ok){
+      logError(`Failed to send snake highscore to server: ${res.status} ${res.statusText}`);
+    }
+  }catch(e){
+    logError('Failed to send snake highscore to server', e);
+  }
+}
 
 function load(){
   try{
@@ -26,6 +94,17 @@ function sanitizeName(str){
   return str.replace(/<[^>]*>/g, '').trim().slice(0, HS_NAME_MAX_LENGTH);
 }
 
+function sanitizeList(list){
+  let changed=false;
+  const cleaned=list.map(e=>{
+    const name=sanitizeName(e.name||'');
+    if(name!==e.name) changed=true;
+    return {...e,name};
+  });
+  if(changed) save(cleaned);
+  return cleaned;
+}
+
 export function addHS(entry){
   const list = load();
   const cleanEntry = { ...entry, name: sanitizeName(entry.name) };
@@ -33,13 +112,15 @@ export function addHS(entry){
   list.sort((a,b) => b.score - a.score);
   const top10 = list.slice(0,10);
   save(top10);
+  sendServerHS(cleanEntry);
   return top10;
 }
 
-export function renderHS(){
+export async function renderHS(){
   const tbody = document.querySelector('#snakeHsTable tbody');
   if(!tbody) return;
-  const list = load();
+  let list = await loadServerHS();
+  list = list ? sanitizeList(list) : sanitizeList(load());
   while(tbody.firstChild) tbody.removeChild(tbody.firstChild);
   list.forEach((e,i)=>{
     const tr = document.createElement('tr');

--- a/test/snakeHighscores.test.js
+++ b/test/snakeHighscores.test.js
@@ -15,10 +15,12 @@ if (!JSDOM) {
   test('addHS sanitizes stored name', () => {
     const dom = new JSDOM('', { url: 'http://localhost' });
     global.localStorage = dom.window.localStorage;
+    global.fetch = async () => ({ ok: true });
     const list = addHS({ name: '<b>Eve</b>', score: 1, date: 'now' });
     assert.strictEqual(list[0].name, 'Eve');
     const saved = JSON.parse(dom.window.localStorage.getItem(HS_KEY));
     assert.strictEqual(saved[0].name, 'Eve');
+    delete global.fetch;
     delete global.localStorage;
   });
 
@@ -31,20 +33,22 @@ if (!JSDOM) {
     delete global.localStorage;
   });
 
-  test('renderHS creates table rows from stored scores', () => {
+  test('renderHS creates table rows from stored scores', async () => {
     const dom = new JSDOM(`<!DOCTYPE html><table id="snakeHsTable"><tbody></tbody></table>`, { url: 'http://localhost' });
     global.document = dom.window.document;
     global.localStorage = dom.window.localStorage;
+    global.fetch = async () => { throw new Error('offline'); };
     const entries = [
       { name: 'Ana', score: 2, date: 'd1' },
       { name: 'Bob', score: 1, date: 'd2' }
     ];
     dom.window.localStorage.setItem(HS_KEY, JSON.stringify(entries));
-    renderHS();
+    await renderHS();
     const rows = dom.window.document.querySelectorAll('#snakeHsTable tbody tr');
     assert.strictEqual(rows.length, 2);
     assert.strictEqual(rows[0].children[1].textContent, 'Ana');
     assert.strictEqual(rows[1].children[2].textContent, '1');
+    delete global.fetch;
     delete global.document;
     delete global.localStorage;
   });


### PR DESCRIPTION
## Summary
- use Supabase REST API to sync highscores when `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are set
- support Supabase for Snake highscores with graceful fallback
- document Supabase setup and local server fallback in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b86f87d2f0832ba9ad90651671f6be