### PR TITLE
Remove best stat from Tetris game over overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,7 +164,6 @@
       <div class="stats" style="margin-top:8px">
         <div class="stat">Score<b id="ovScore">0</b></div>
         <div class="stat">Lines<b id="ovLines">0</b></div>
-        <div class="stat">Best<b id="ovBest">0</b></div>
       </div>
       <div class="buttons" style="justify-content:center;margin-top:14px">
         <button id="btnRestart">Neu starten</button>

--- a/src/game.js
+++ b/src/game.js
@@ -50,10 +50,9 @@ export function initGame(){
 
   // ==== Overlay helpers
   const overlay = () => document.getElementById('overlay');
-  function showOverlay({score, lines, best}){
+  function showOverlay({score, lines}){
     document.getElementById('ovScore').textContent = score;
     document.getElementById('ovLines').textContent = lines;
-    document.getElementById('ovBest').textContent = best;
     overlay().classList.add('show');
   }
   function hideOverlay(){ overlay().classList.remove('show'); }
@@ -290,7 +289,7 @@ export function initGame(){
     addHS({ name, score, lines, date: new Date().toISOString().slice(0,10) }, mode);
     renderHS(mode);
     updateSide();
-    showOverlay({score, lines, best});
+    showOverlay({score, lines});
     sfx.gameover();
   }
 


### PR DESCRIPTION
## Summary
- remove the redundant "Best" stat from the Tetris game over overlay markup
- stop the game over overlay code from trying to populate the removed element

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca84798960832b93d6e4e01ee29dda