### PR TITLE
Add intro screen for player name and game selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,25 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <div class="controls top-controls" style="justify-content:center;margin-bottom:8px">
+  <div id="introScreen" role="dialog" aria-modal="true">
+    <div class="intro-card">
+      <h1>👋 Willkommen</h1>
+      <p>Bitte gib deinen Namen ein und wähle das Spiel, mit dem du starten möchtest.</p>
+      <form id="introForm" class="intro-form" novalidate>
+        <label class="intro-label">Spielername
+          <input id="introName" class="input" autocomplete="off" />
+        </label>
+        <label class="intro-label">Spiel
+          <select id="introGameSelect" class="input">
+            <option value="tetris">Tetris</option>
+            <option value="snake">Snake</option>
+          </select>
+        </label>
+        <button type="submit" class="intro-submit"><span class="material-icons">play_arrow</span> Los geht's</button>
+      </form>
+    </div>
+  </div>
+  <div id="globalControls" class="controls top-controls hidden" style="justify-content:center;margin-bottom:8px">
     <label>Spiel:
       <select id="gameSelect" class="input">
         <option value="tetris">Tetris</option>
@@ -23,7 +41,7 @@
       </select>
     </label>
   </div>
-  <div id="tetrisWrap">
+  <div id="tetrisWrap" class="hidden">
     <div class="wrap">
     <div>
       <h1>🧱 Tetris</h1>

--- a/src/main.js
+++ b/src/main.js
@@ -14,9 +14,11 @@ const gameSelect = document.getElementById('gameSelect');
 const tetrisWrap = document.getElementById('tetrisWrap');
 const snakeWrap = document.getElementById('snakeWrap');
 const menuOverlay = document.getElementById('menuOverlay');
+let introCompleted = false;
 
 function switchGame(){
   if(!gameSelect || !tetrisWrap || !snakeWrap) return;
+  if(!introCompleted) return;
   if(menuOverlay && menuOverlay.classList.contains('show')){
     toggleMenuOverlay();
   }
@@ -38,8 +40,20 @@ function switchGame(){
 
 if(gameSelect){
   gameSelect.addEventListener('change', switchGame);
-  switchGame();
 }
+
+document.addEventListener('intro-complete', event => {
+  introCompleted = true;
+  const selectedGame = event.detail?.game || 'tetris';
+  if(gameSelect){
+    gameSelect.value = selectedGame;
+  }
+  const introScreen = document.getElementById('introScreen');
+  if(introScreen){
+    introScreen.setAttribute('aria-hidden', 'true');
+  }
+  switchGame();
+});
 
 // Register external Service Worker (works on Netlify & GitHub Pages)
 if ('serviceWorker' in navigator) {

--- a/src/ui.js
+++ b/src/ui.js
@@ -9,6 +9,33 @@ export function initUI(){
 
   const btnThemes = document.querySelectorAll('#themeToggle');
   const themeIcons = document.querySelectorAll('#themeIcon');
+  const globalControls = document.getElementById('globalControls');
+  const introScreen = document.getElementById('introScreen');
+  const introForm = document.getElementById('introForm');
+  const introNameInput = document.getElementById('introName');
+  const introGameSelect = document.getElementById('introGameSelect');
+  const gameSelect = document.getElementById('gameSelect');
+  if(introScreen){
+    introScreen.setAttribute('aria-hidden', 'false');
+  }
+  if(introGameSelect && gameSelect){
+    introGameSelect.value = gameSelect.value;
+  }
+
+  function dispatchIntroComplete(game){
+    const detail = { game };
+    const CustomEvt = (typeof window !== 'undefined' && typeof window.CustomEvent === 'function')
+      ? window.CustomEvent
+      : (typeof CustomEvent === 'function' ? CustomEvent : null);
+    let evt;
+    if(CustomEvt){
+      evt = new CustomEvt('intro-complete', { detail });
+    }else{
+      evt = new Event('intro-complete');
+      evt.detail = detail;
+    }
+    document.dispatchEvent(evt);
+  }
   function updateThemeIcon(){
     themeIcons.forEach(icon => {
       icon.textContent = document.body.classList.contains('theme-light') ? 'dark_mode' : 'light_mode';
@@ -39,8 +66,9 @@ export function initUI(){
     setTimeout(()=>inputPlayer.focus(),0);
   }
 
-  if (localStorage.getItem(PLAYER_KEY) === null) {
-    openPlayerDialog();
+  if(introNameInput){
+    introNameInput.value = playerName;
+    setTimeout(()=>introNameInput.focus(),0);
   }
 
   if (btnSave) {
@@ -48,6 +76,9 @@ export function initUI(){
       playerName = inputPlayer.value.trim() || 'Player';
       localStorage.setItem(PLAYER_KEY, playerName);
       dlgPlayer.close();
+      if(introNameInput){
+        introNameInput.value = playerName;
+      }
     });
   }
   if (btnCancel) {
@@ -57,6 +88,35 @@ export function initUI(){
   }
   const btnPlayers = document.querySelectorAll('#btnPlayer');
   btnPlayers.forEach(btn => btn.addEventListener('click', openPlayerDialog));
+
+  if(introForm){
+    introForm.addEventListener('submit', e => {
+      e.preventDefault();
+      playerName = (introNameInput?.value.trim() || 'Player');
+      localStorage.setItem(PLAYER_KEY, playerName);
+      if(inputPlayer){
+        inputPlayer.value = playerName;
+      }
+      const selectedGame = introGameSelect?.value || 'tetris';
+      if(gameSelect){
+        gameSelect.value = selectedGame;
+      }
+      if(globalControls){
+        globalControls.classList.remove('hidden');
+      }
+      if(introScreen){
+        introScreen.classList.add('hide');
+        introScreen.setAttribute('aria-hidden', 'true');
+      }
+      dispatchIntroComplete(selectedGame);
+    });
+  }else{
+    if(globalControls){
+      globalControls.classList.remove('hidden');
+    }
+    const selectedGame = gameSelect?.value || 'tetris';
+    dispatchIntroComplete(selectedGame);
+  }
 
   document.addEventListener('contextmenu', e => e.preventDefault());
 }

--- a/styles.css
+++ b/styles.css
@@ -80,3 +80,13 @@ select.input option{background:var(--input-bg);color:var(--fg)}
 [aria-label]::before,[aria-label]::after{display:none;content:none}
 dialog{border:1px solid var(--panel-border);background:var(--panel-bg);color:var(--fg);border-radius:12px;padding:16px}
 dialog::backdrop{background:rgba(0,0,0,.45)}
+#introScreen{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.55);backdrop-filter:blur(6px);z-index:10000;transition:opacity .3s ease,visibility .3s ease}
+#introScreen.hide{opacity:0;visibility:hidden;pointer-events:none}
+#introScreen .intro-card{background:color-mix(in srgb,var(--panel-bg),transparent 10%);border:1px solid var(--panel-border);border-radius:20px;padding:28px 32px;max-width:420px;margin:16px;box-shadow:0 18px 40px color-mix(in srgb,var(--bg),#000 40%);text-align:center}
+#introScreen h1{margin:0 0 8px;font-size:30px;letter-spacing:1px}
+#introScreen p{margin:0 0 20px;color:var(--muted)}
+.intro-form{display:flex;flex-direction:column;gap:16px}
+.intro-label{display:flex;flex-direction:column;gap:6px;text-align:left;font-weight:600}
+.intro-label .input{width:100%}
+.intro-submit{align-self:center;font-size:16px;padding:12px 20px}
+.intro-submit .material-icons{font-size:22px}


### PR DESCRIPTION
## Summary
- introduce a full-screen intro overlay so users enter their name and choose between Tetris or Snake before seeing the playfield
- sync the intro form with existing player dialog logic and only show global controls/game layout after the intro is confirmed
- add styles and event wiring to hide the intro smoothly and switch to the selected game once onboarding is complete

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc27a44c4c832b925b0419cf225d07