### PR TITLE
Add accent primary button styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
             <option value="snake">Snake</option>
           </select>
         </label>
-        <button type="submit" class="intro-submit"><span class="material-icons">play_arrow</span> Los geht's</button>
+        <button type="submit" class="intro-submit button-primary"><span class="material-icons">play_arrow</span> Los geht's</button>
       </form>
     </div>
   </div>
@@ -49,7 +49,7 @@
         <button id="btnMenu"><span class="material-icons">menu</span> Menü</button>
         <button id="btnPlayer"><span class="material-icons">person</span> Spieler</button>
         <button id="themeToggle"><span class="material-icons" id="themeIcon">brightness_6</span> Theme</button>
-        <button id="btnStart"><span class="material-icons">play_arrow</span> Start/Neu</button>
+        <button id="btnStart" class="button-primary"><span class="material-icons">play_arrow</span> Start/Neu</button>
         <button id="btnPause"><span class="material-icons">pause</span> Pause</button>
         <label>Modus:
           <select id="modeSelect" class="input">
@@ -116,7 +116,7 @@
             <button id="snakeBtnMenu"><span class="material-icons">menu</span> Menü</button>
             <button id="btnPlayer"><span class="material-icons">person</span> Spieler</button>
             <button id="themeToggle"><span class="material-icons" id="themeIcon">brightness_6</span> Theme</button>
-            <button id="snakeStart"><span class="material-icons">play_arrow</span> Start/Neu</button>
+            <button id="snakeStart" class="button-primary"><span class="material-icons">play_arrow</span> Start/Neu</button>
             <button id="snakePause"><span class="material-icons">pause</span> Pause</button>
             <label>Modus:
               <select id="snakeModeSelect" class="input">
@@ -211,7 +211,7 @@
         <div class="stat">Lines<b id="ovLines">0</b></div>
       </div>
       <div class="buttons" style="justify-content:center;margin-top:14px">
-        <button id="btnRestart">Neu starten</button>
+        <button id="btnRestart" class="button-primary">Neu starten</button>
         <button id="btnClose">Schließen</button>
       </div>
     </div>
@@ -234,7 +234,7 @@
       </table>
       <div class="controls" style="justify-content:center;margin-top:14px">
         <button id="snakeBtnResetHS">Highscores löschen</button>
-        <button id="snakeBtnRestart">Neu starten</button>
+        <button id="snakeBtnRestart" class="button-primary">Neu starten</button>
         <button id="snakeBtnClose">Schließen</button>
       </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,12 @@
   --canvas-bg:#0a0c10; --canvas-border:#202533;
   --stat-bg:#0d1119; --stat-border:#1f2533;
   --button-bg:#121722; --button-border:#2a3142; --button-hover-bg:#1a2030;
+  --button-primary-bg:color-mix(in srgb,var(--accent) 92%,#0b1019 8%);
+  --button-primary-border:color-mix(in srgb,var(--accent) 55%,#02060b 45%);
+  --button-primary-hover-bg:color-mix(in srgb,var(--accent) 100%,#060b15 0%);
+  --button-primary-color:#03121f;
+  --button-primary-shadow:0 14px 32px color-mix(in srgb,var(--accent),transparent 70%);
+  --button-primary-hover-shadow:0 18px 38px color-mix(in srgb,var(--accent),transparent 60%);
   --kbd-bg:#222739; --kbd-border:#2c3550;
   --mini-bg:#0d1119; --mini-border:#1f2533;
   --input-bg:#0d1119; --input-border:#1f2533;
@@ -15,6 +21,12 @@
   --canvas-bg:#ffffff; --canvas-border:#dadce0;
   --stat-bg:#f1f3f4; --stat-border:#dadce0;
   --button-bg:#f8f9fa; --button-border:#dadce0; --button-hover-bg:#e8eaed;
+  --button-primary-bg:#0b62d1;
+  --button-primary-border:#0a58bb;
+  --button-primary-hover-bg:#0a58bb;
+  --button-primary-color:#ffffff;
+  --button-primary-shadow:0 12px 28px color-mix(in srgb,#0b62d1,transparent 65%);
+  --button-primary-hover-shadow:0 16px 34px color-mix(in srgb,#0b62d1,transparent 55%);
   --kbd-bg:#e8eaed; --kbd-border:#dadce0;
   --mini-bg:#f1f3f4; --mini-border:#dadce0;
   --input-bg:#f8f9fa; --input-border:#dadce0;
@@ -90,3 +102,6 @@ dialog::backdrop{background:rgba(0,0,0,.45)}
 .intro-label .input{width:100%}
 .intro-submit{align-self:center;font-size:16px;padding:12px 20px}
 .intro-submit .material-icons{font-size:22px}
+.button-primary{background:var(--button-primary-bg);border:1px solid var(--button-primary-border);color:var(--button-primary-color);box-shadow:var(--button-primary-shadow);transition:background .2s ease,transform .1s ease,box-shadow .2s ease}
+.button-primary:hover{background:var(--button-primary-hover-bg);box-shadow:var(--button-primary-hover-shadow);transform:translateY(-1px)}
+.button-primary:active{transform:scale(.95)}


### PR DESCRIPTION
## Summary
- add a primary button variant with accent-forward colors and hover styling for light and dark themes
- apply the primary button styling to key start and restart actions across the UI

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd2978c7f0832b92f7cb44520c759a