### PR TITLE
Center menu overlay panels within wrapper

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,50 +154,52 @@
       <button id="tabScore" role="tab" aria-controls="scorePanel">Scoreboard</button>
       <button id="tabSettings" role="tab" aria-controls="settingsPanel">Einstellungen</button>
     </div>
-    <div class="panel" id="scorePanel" style="margin-top:16px;">
-      <h3>Scoreboard – <span id="hsModeLabel">Tetris – Classic (endlos)</span></h3>
-      <div class="controls" style="flex-wrap:wrap;gap:8px;">
-        <label>Spiel:
-          <select id="scoreGameSelect" class="input">
-            <option value="tetris">Tetris</option>
-            <option value="snake">Snake</option>
-          </select>
-        </label>
-        <label>Modus:
-          <select id="scoreModeSelect" class="input">
-            <option value="classic">Classic (endlos)</option>
-            <option value="classic_once">Classic – 1 Drehung</option>
-            <option value="ultra">Ultra – 2 Minuten</option>
-          </select>
-        </label>
-        <button id="btnResetHS">Highscores löschen</button>
+    <div class="menu-overlay__inner">
+      <div class="panel" id="scorePanel" style="margin-top:16px;">
+        <h3>Scoreboard – <span id="hsModeLabel">Tetris – Classic (endlos)</span></h3>
+        <div class="controls" style="flex-wrap:wrap;gap:8px;">
+          <label>Spiel:
+            <select id="scoreGameSelect" class="input">
+              <option value="tetris">Tetris</option>
+              <option value="snake">Snake</option>
+            </select>
+          </label>
+          <label>Modus:
+            <select id="scoreModeSelect" class="input">
+              <option value="classic">Classic (endlos)</option>
+              <option value="classic_once">Classic – 1 Drehung</option>
+              <option value="ultra">Ultra – 2 Minuten</option>
+            </select>
+          </label>
+          <button id="btnResetHS">Highscores löschen</button>
+        </div>
+        <table class="table" id="hsTable">
+          <thead>
+            <tr><th>#</th><th>Name</th><th>Score</th><th>Lines</th><th>Datum</th></tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+        <table class="table hidden" id="snakeScoreTable">
+          <thead>
+            <tr><th>#</th><th>Name</th><th>Score</th><th>Datum</th></tr>
+          </thead>
+          <tbody></tbody>
+        </table>
       </div>
-      <table class="table" id="hsTable">
-        <thead>
-          <tr><th>#</th><th>Name</th><th>Score</th><th>Lines</th><th>Datum</th></tr>
-        </thead>
-        <tbody></tbody>
-      </table>
-      <table class="table hidden" id="snakeScoreTable">
-        <thead>
-          <tr><th>#</th><th>Name</th><th>Score</th><th>Datum</th></tr>
-        </thead>
-        <tbody></tbody>
-      </table>
-    </div>
 
-    <div class="panel" id="settingsPanel" style="margin-top:16px;display:none;">
-      <h3>Einstellungen</h3>
-      <div class="controls">
-        <label><input type="checkbox" id="optSound" checked> Sound</label>
-        <label><input type="checkbox" id="optGhost" checked> Ghost Piece</label>
-        <label><input type="checkbox" id="optSoftDropPoints" checked> Soft‑Drop Punkte</label>
-        <label>Farben:
-          <select id="optPalette">
-            <option value="standard">Standard</option>
-            <option value="accessible">Barrierefrei</option>
-          </select>
-        </label>
+      <div class="panel" id="settingsPanel" style="margin-top:16px;display:none;">
+        <h3>Einstellungen</h3>
+        <div class="controls">
+          <label><input type="checkbox" id="optSound" checked> Sound</label>
+          <label><input type="checkbox" id="optGhost" checked> Ghost Piece</label>
+          <label><input type="checkbox" id="optSoftDropPoints" checked> Soft‑Drop Punkte</label>
+          <label>Farben:
+            <select id="optPalette">
+              <option value="standard">Standard</option>
+              <option value="accessible">Barrierefrei</option>
+            </select>
+          </label>
+        </div>
       </div>
     </div>
   </div>

--- a/styles.css
+++ b/styles.css
@@ -60,6 +60,9 @@ select.input option{background:var(--input-bg);color:var(--fg)}
 #menuOverlay{position:fixed;inset:0;overflow-y:auto;background:rgba(0,0,0,.6);padding:24px 16px;opacity:0;pointer-events:none;transition:opacity .25s ease;z-index:9998}
 #menuOverlay.show{opacity:1;pointer-events:auto}
 #menuOverlay [role="tablist"] button.active{background:var(--button-hover-bg)}
+#menuOverlay .menu-overlay__inner{max-width:720px;margin:0 auto;display:flex;flex-direction:column;gap:16px}
+#menuOverlay .menu-overlay__inner .controls{justify-content:center}
+#menuOverlay .panel{width:100%;box-sizing:border-box}
 /* Overlay Game Over */
 #overlay{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;opacity:0;pointer-events:none;transition:opacity .25s ease;background:rgba(0,0,0,.45);backdrop-filter:blur(2px) saturate(1.1);z-index:9999}
 #overlay.show{opacity:1;pointer-events:auto}


### PR DESCRIPTION
## Summary
- wrap the scoreboard and settings panels inside a dedicated menu overlay container
- limit the overlay content width, center the controls, and ensure panels expand to the full wrapper width

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd297ae8b0832b98994bba4f8dc55a