### PR TITLE
Prevent snake canvas double-tap scrolling

### DIFF
--- a/src/snake.js
+++ b/src/snake.js
@@ -355,6 +355,13 @@ export function initSnake(){
   btnStart.addEventListener('click', start);
   if(btnPause) btnPause.addEventListener('click', togglePause);
   canvas.addEventListener('pointerdown', handlePointer, {passive:false});
+  const preventTouchScroll = e => {
+    if(e.cancelable){
+      e.preventDefault();
+    }
+  };
+  canvas.addEventListener('touchstart', preventTouchScroll, {passive:false});
+  canvas.addEventListener('touchmove', preventTouchScroll, {passive:false});
   document.addEventListener('keydown', handleKey);
   if(btnRestart) btnRestart.addEventListener('click', start);
   if(btnClose) btnClose.addEventListener('click', hideOverlay);

--- a/styles.css
+++ b/styles.css
@@ -45,6 +45,7 @@ p{color:var(--muted);margin:0 0 12px}
 }
 .panel{background:color-mix(in srgb,var(--panel-bg),transparent 20%);backdrop-filter:blur(8px);border:1px solid var(--panel-border);border-radius:16px;padding:14px 16px;box-shadow:0 10px 30px color-mix(in srgb,var(--bg),#000 30%);min-width:0}
 canvas{display:block;background:var(--canvas-bg);border-radius:12px;border:1px solid var(--canvas-border)}
+#snakeCanvas{touch-action:none;-webkit-user-select:none;user-select:none}
 .stats{display:flex;flex-direction:column;gap:8px}
 .stat{background:var(--stat-bg);border:1px solid var(--stat-border);border-radius:12px;padding:10px;text-align:center}
 .stat b{display:block;font-size:22px;margin-top:6px;color:var(--accent);font-weight:600;letter-spacing:1px}


### PR DESCRIPTION
## Summary
- prevent the snake canvas from triggering page scrolling by cancelling touchstart and touchmove defaults
- disable browser gestures like text selection on the snake canvas via CSS touch-action and user-select rules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf99e55438832b8c99215d624b980e