### PR TITLE
Set light theme snake board background to white

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -50,7 +50,7 @@
   --sudoku-block-surface-alt:color-mix(in srgb,var(--accent) 10%,transparent 90%);
   --sudoku-block-chess:color-mix(in srgb,var(--accent) 16%,transparent 84%);
   --overlay-celebration:color-mix(in srgb,var(--accent) 65%,#fff 25%);
-  --snake-board-surface:color-mix(in srgb,var(--accent) 20%,#ffffff 80%);
+  --snake-board-surface:#ffffff;
   --snake-board-border:color-mix(in srgb,var(--accent) 35%,transparent 65%);
   --snake-board-shadow:0 18px 34px color-mix(in srgb,var(--accent),transparent 86%);
 }


### PR DESCRIPTION
## Summary
- set the light theme snake board surface color to pure white so the playfield background is white

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d52189961c832bbf3c3a39255619fb