### PR TITLE
Center Sudoku top controls

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -341,6 +341,7 @@ b{color:var(--fg);font-weight:600}
 .controls--bar{justify-content:space-between;align-items:center;margin-bottom:12px;gap:12px}
 .top-controls{margin-bottom:12px;gap:10px;flex-wrap:wrap}
 #snakeWrap .top-controls{justify-content:center}
+#sudokuWrap .top-controls{justify-content:center}
 #snakeWrap .top-controls > *{margin-left:0;margin-right:0}
 .input{background:var(--input-bg);border:1px solid var(--input-border);border-radius:12px;padding:10px 12px;color:var(--fg);transition:border-color .2s ease,box-shadow .2s ease,background .2s ease}
 .input:focus{outline:none;border-color:color-mix(in srgb,var(--accent),transparent 45%);box-shadow:0 0 0 3px color-mix(in srgb,var(--accent),transparent 80%)}


### PR DESCRIPTION
## Summary
- center the Sudoku top control bar to mirror the board and keypad alignment

## Testing
- Manual verification in Chromium via Playwright at 1200px and 480px viewports

------
https://chatgpt.com/codex/tasks/task_e_68e2327482f8832bbb271d174c9e9b3d