### PR TITLE
Add Nonogram puzzle to game collection

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
             <option value="tetris">Tetris</option>
             <option value="snake">Snake</option>
             <option value="sudoku">Sudoku</option>
+            <option value="nonogram">Nonogramm</option>
           </select>
         </label>
         <button type="submit" class="intro-submit button-primary"><span class="icon" aria-hidden="true">▶</span> Los geht's</button>
@@ -42,6 +43,7 @@
         <option value="tetris">Tetris</option>
         <option value="snake">Snake</option>
         <option value="sudoku">Sudoku</option>
+        <option value="nonogram">Nonogramm</option>
       </select>
     </label>
   </div>
@@ -224,6 +226,73 @@
     </div>
   </div>
 
+  <div id="nonogramWrap" class="hidden">
+    <div class="wrap">
+      <div>
+        <div class="page-header">
+          <h1 class="page-title"><span class="page-title__icon" aria-hidden="true">🧠</span><span class="page-title__text">Nonogramm</span></h1>
+        </div>
+        <div class="controls top-controls">
+          <button id="nonogramBtnMenu"><span class="icon" aria-hidden="true">☰</span> Menü</button>
+          <button id="themeToggle"><span class="icon" data-theme-icon aria-hidden="true">🌙</span> Theme</button>
+          <button id="nonogramStart" class="button-primary"><span class="icon" aria-hidden="true">↻</span> Neues Rätsel</button>
+          <label>Rätsel:
+            <select id="nonogramPuzzleSelect" class="input">
+              <option value="classic">10×10 Rätsel</option>
+            </select>
+          </label>
+        </div>
+        <div class="panel nonogram-panel">
+          <div class="controls nonogram-stats" style="justify-content:center;margin:0 0 12px;">
+            <span class="timer" id="nonogramTimer">Zeit: 00:00</span>
+            <span class="timer" id="nonogramBest">Best: --</span>
+          </div>
+          <div id="nonogramGrid" class="nonogram-grid" aria-label="Nonogramm Spielfeld">
+            <div class="nonogram-grid__corner" aria-hidden="true"></div>
+            <div class="nonogram-clues nonogram-clues--cols" id="nonogramColClues"></div>
+            <div class="nonogram-clues nonogram-clues--rows" id="nonogramRowClues"></div>
+            <div class="nonogram-cells" id="nonogramCells" role="group" aria-label="Nonogramm Gitter"></div>
+          </div>
+          <div class="nonogram-tools" role="group" aria-label="Werkzeugauswahl">
+            <button type="button" data-nonogram-tool="fill" class="button-primary nonogram-tool" aria-pressed="true"><span class="icon" aria-hidden="true">⬛</span> Füllen</button>
+            <button type="button" data-nonogram-tool="mark" class="nonogram-tool" aria-pressed="false"><span class="icon" aria-hidden="true">✕</span> Markieren</button>
+            <button type="button" data-nonogram-tool="clear" class="nonogram-tool" aria-pressed="false"><span class="icon" aria-hidden="true">⌫</span> Leeren</button>
+          </div>
+        </div>
+        <div class="panel panel--info" style="margin-top:16px">
+          <div class="panel__header">
+            <h3>So funktioniert's</h3>
+          </div>
+          <p>Nutze die Hinweise links und oberhalb des Gitters, um festzulegen, welche Felder gefüllt werden müssen.</p>
+          <p>Tippe auf ein Feld, um zwischen gefüllt, markiert oder leer zu wechseln. Ein Rechtsklick markiert ein Feld direkt.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div id="nonogramOverlay" aria-hidden="true">
+    <div class="overlay-card" role="dialog" aria-modal="true" aria-labelledby="nonogramOvTitle">
+      <h2 id="nonogramOvTitle">🎉 Nonogramm gelöst!</h2>
+      <p>Deine Zeit: <b id="nonogramOvTime">00:00</b></p>
+      <p>Beste Zeit: <b id="nonogramOvBest">--</b></p>
+      <div class="buttons" style="justify-content:center;margin-top:12px;">
+        <button id="nonogramBtnRestart" class="button-primary"><span class="icon" aria-hidden="true">↻</span> Noch einmal</button>
+        <button id="nonogramBtnClose"><span class="icon" aria-hidden="true">✕</span> Schließen</button>
+      </div>
+      <div class="panel panel--info" style="margin-top:16px;">
+        <div class="panel__header">
+          <h3>Top-Zeiten</h3>
+        </div>
+        <table class="table" id="nonogramOvTable">
+          <thead>
+            <tr><th>#</th><th>Name</th><th>Zeit</th><th>Datum</th></tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
   <div id="sudokuOverlay" aria-hidden="true">
     <div class="overlay-card" role="dialog" aria-modal="true" aria-labelledby="sudokuOvTitle">
       <h2 id="sudokuOvTitle">🎉 Sudoku gelöst!</h2>
@@ -264,6 +333,7 @@
               <option value="tetris">Tetris</option>
               <option value="snake">Snake</option>
               <option value="sudoku">Sudoku</option>
+              <option value="nonogram">Nonogramm</option>
             </select>
           </label>
           <label>Modus:
@@ -288,6 +358,12 @@
           <tbody></tbody>
         </table>
         <table class="table hidden" id="sudokuScoreTable">
+          <thead>
+            <tr><th>#</th><th>Name</th><th>Zeit</th><th>Datum</th></tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+        <table class="table hidden" id="nonogramScoreTable">
           <thead>
             <tr><th>#</th><th>Name</th><th>Zeit</th><th>Datum</th></tr>
           </thead>

--- a/src/constants.js
+++ b/src/constants.js
@@ -99,3 +99,10 @@ export const SUDOKU_DIFFICULTY_LABELS = {
 };
 export const SUDOKU_HS_KEY_BASE = 'sudoku_highscores_v1';
 export const SUDOKU_BEST_KEY_BASE = 'sudoku_best_v1';
+
+export const NONOGRAM_PUZZLES = ['classic'];
+export const NONOGRAM_PUZZLE_LABELS = {
+  classic: '10×10 Rätsel'
+};
+export const NONOGRAM_HS_KEY_BASE = 'nonogram_highscores_v1';
+export const NONOGRAM_BEST_KEY_BASE = 'nonogram_best_v1';

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import { initUI } from './ui.js';
 import { initGame } from './game.js';
 import { initSnake } from './snake.js';
 import { initSudoku } from './sudoku.js';
+import { initNonogram } from './nonogram.js';
 import { initMenu, toggleMenuOverlay } from './menu.js';
 import { logError } from './logger.js';
 
@@ -11,11 +12,13 @@ initMenu();
 const tetrisGame = initGame();
 const snakeGame = initSnake();
 const sudokuGame = initSudoku();
+const nonogramGame = initNonogram();
 
 const gameSelect = document.getElementById('gameSelect');
 const tetrisWrap = document.getElementById('tetrisWrap');
 const snakeWrap = document.getElementById('snakeWrap');
 const sudokuWrap = document.getElementById('sudokuWrap');
+const nonogramWrap = document.getElementById('nonogramWrap');
 const menuOverlay = document.getElementById('menuOverlay');
 let introCompleted = false;
 
@@ -34,6 +37,11 @@ const games = {
     controller: sudokuGame,
     wrapper: sudokuWrap,
     title: 'Sudoku'
+  },
+  nonogram: {
+    controller: nonogramGame,
+    wrapper: nonogramWrap,
+    title: 'Nonogramm'
   }
 };
 

--- a/src/menu.js
+++ b/src/menu.js
@@ -7,11 +7,15 @@ import {
   SNAKE_BEST_KEY_BASE,
   SUDOKU_DIFFICULTIES,
   SUDOKU_DIFFICULTY_LABELS,
-  SUDOKU_BEST_KEY_BASE
+  SUDOKU_BEST_KEY_BASE,
+  NONOGRAM_PUZZLES,
+  NONOGRAM_PUZZLE_LABELS,
+  NONOGRAM_BEST_KEY_BASE
 } from './constants.js';
 import { renderHS as renderTetrisHS, saveHS, bestKey } from './highscores.js';
 import { renderHS as renderSnakeHS, clearHS as clearSnakeHS } from './snakeHighscores.js';
 import { renderHS as renderSudokuHS, clearHS as clearSudokuHS } from './sudokuHighscores.js';
+import { renderHS as renderNonogramHS, clearHS as clearNonogramHS } from './nonogramHighscores.js';
 let overlay;
 let btnClose;
 let lastFocused = null;
@@ -33,14 +37,17 @@ export function initMenu(){
   const hsTable = document.getElementById('hsTable');
   const snakeTable = document.getElementById('snakeScoreTable');
   const sudokuTable = document.getElementById('sudokuScoreTable');
+  const nonogramTable = document.getElementById('nonogramScoreTable');
   const hsLabel = document.getElementById('hsModeLabel');
   const lastModeByGame = {
     tetris: TETRIS_MODES[0],
     snake: SNAKE_MODES[0],
-    sudoku: SUDOKU_DIFFICULTIES[0]
+    sudoku: SUDOKU_DIFFICULTIES[0],
+    nonogram: NONOGRAM_PUZZLES[0]
   };
   const snakeBestKey = mode => `${SNAKE_BEST_KEY_BASE}_${mode}`;
   const sudokuBestKey = mode => `${SUDOKU_BEST_KEY_BASE}_${mode}`;
+  const nonogramBestKey = mode => `${NONOGRAM_BEST_KEY_BASE}_${mode}`;
 
   function fillModeOptions(game, preferred){
     if(!scoreModeSelect) return preferred;
@@ -52,6 +59,9 @@ export function initMenu(){
     }else if(game === 'sudoku'){
       modes = SUDOKU_DIFFICULTIES;
       labels = SUDOKU_DIFFICULTY_LABELS;
+    }else if(game === 'nonogram'){
+      modes = NONOGRAM_PUZZLES;
+      labels = NONOGRAM_PUZZLE_LABELS;
     }else{
       modes = TETRIS_MODES;
       labels = MODE_LABELS;
@@ -74,18 +84,28 @@ export function initMenu(){
       if(hsTable) hsTable.classList.add('hidden');
       if(snakeTable) snakeTable.classList.remove('hidden');
       if(sudokuTable) sudokuTable.classList.add('hidden');
+      if(nonogramTable) nonogramTable.classList.add('hidden');
       if(hsLabel) hsLabel.textContent = `Snake – ${SNAKE_MODE_LABELS[mode] || mode}`;
       await renderSnakeHS(mode, { tableSelector: '#snakeScoreTable' });
     } else if(game === 'sudoku'){
       if(hsTable) hsTable.classList.add('hidden');
       if(snakeTable) snakeTable.classList.add('hidden');
       if(sudokuTable) sudokuTable.classList.remove('hidden');
+      if(nonogramTable) nonogramTable.classList.add('hidden');
       if(hsLabel) hsLabel.textContent = `Sudoku – ${SUDOKU_DIFFICULTY_LABELS[mode] || mode}`;
       renderSudokuHS(mode, { tableSelector: '#sudokuScoreTable' });
+    } else if(game === 'nonogram'){
+      if(hsTable) hsTable.classList.add('hidden');
+      if(snakeTable) snakeTable.classList.add('hidden');
+      if(sudokuTable) sudokuTable.classList.add('hidden');
+      if(nonogramTable) nonogramTable.classList.remove('hidden');
+      if(hsLabel) hsLabel.textContent = `Nonogramm – ${NONOGRAM_PUZZLE_LABELS[mode] || mode}`;
+      renderNonogramHS(mode, { tableSelector: '#nonogramScoreTable' });
     } else {
       if(hsTable) hsTable.classList.remove('hidden');
       if(snakeTable) snakeTable.classList.add('hidden');
       if(sudokuTable) sudokuTable.classList.add('hidden');
+      if(nonogramTable) nonogramTable.classList.add('hidden');
       await renderTetrisHS(mode, { tableSelector: '#hsTable', labelSelector: '#hsModeLabel' });
     }
   }
@@ -94,6 +114,7 @@ export function initMenu(){
   const tetrisModeSelect = document.getElementById('modeSelect');
   const snakeModeSelect = document.getElementById('snakeModeSelect');
   const sudokuModeSelect = document.getElementById('sudokuDifficulty');
+  const nonogramModeSelect = document.getElementById('nonogramPuzzleSelect');
 
   async function syncScoreboardWithActiveGame(){
     if(!scoreGameSelect || !scoreModeSelect) return;
@@ -104,6 +125,8 @@ export function initMenu(){
       currentMode = snakeModeSelect ? snakeModeSelect.value : lastModeByGame.snake;
     }else if(activeGame === 'sudoku'){
       currentMode = sudokuModeSelect ? sudokuModeSelect.value : lastModeByGame.sudoku;
+    }else if(activeGame === 'nonogram'){
+      currentMode = nonogramModeSelect ? nonogramModeSelect.value : lastModeByGame.nonogram;
     }else{
       currentMode = tetrisModeSelect ? tetrisModeSelect.value : lastModeByGame.tetris;
     }
@@ -116,7 +139,8 @@ export function initMenu(){
   [
     document.getElementById('btnMenu'),
     document.getElementById('snakeBtnMenu'),
-    document.getElementById('sudokuBtnMenu')
+    document.getElementById('sudokuBtnMenu'),
+    document.getElementById('nonogramBtnMenu')
   ]
     .filter(Boolean)
     .forEach(btn => btn.addEventListener('click', toggleMenuOverlay));
@@ -177,6 +201,11 @@ export function initMenu(){
         localStorage.removeItem(sudokuBestKey(mode));
         await updateScoreboard(game, mode);
         document.dispatchEvent(new CustomEvent('sudokuHsCleared', { detail: { mode } }));
+      } else if(game === 'nonogram'){
+        clearNonogramHS(mode);
+        localStorage.removeItem(nonogramBestKey(mode));
+        await updateScoreboard(game, mode);
+        document.dispatchEvent(new CustomEvent('nonogramHsCleared', { detail: { mode } }));
       } else {
         saveHS([], mode);
         localStorage.removeItem(bestKey(mode));

--- a/src/nonogram.js
+++ b/src/nonogram.js
@@ -1,0 +1,448 @@
+import {
+  PLAYER_KEY,
+  NONOGRAM_PUZZLES,
+  NONOGRAM_PUZZLE_LABELS,
+  NONOGRAM_BEST_KEY_BASE
+} from './constants.js';
+import {
+  addHS,
+  renderHS,
+  formatNonogramTime,
+  getBestTime
+} from './nonogramHighscores.js';
+import { createOverlayController } from './overlay.js';
+
+const PUZZLES = {
+  classic: {
+    title: 'Pixel-Herz',
+    grid: [
+      [0,1,1,0,0,0,0,1,1,0],
+      [1,1,1,1,0,0,1,1,1,1],
+      [1,1,1,1,1,1,1,1,1,1],
+      [1,1,1,1,1,1,1,1,1,1],
+      [0,1,1,1,1,1,1,1,1,0],
+      [0,0,1,1,1,1,1,1,0,0],
+      [0,0,0,1,1,1,1,0,0,0],
+      [0,0,0,0,1,1,0,0,0,0],
+      [0,0,0,0,1,0,0,0,0,0],
+      [0,0,0,0,1,0,0,0,0,0]
+    ]
+  }
+};
+
+export function initNonogram(){
+  const gridWrapper = document.getElementById('nonogramGrid');
+  const gridEl = document.getElementById('nonogramCells');
+  const rowCluesEl = document.getElementById('nonogramRowClues');
+  const colCluesEl = document.getElementById('nonogramColClues');
+  const timerEl = document.getElementById('nonogramTimer');
+  const bestEl = document.getElementById('nonogramBest');
+  const startBtn = document.getElementById('nonogramStart');
+  const puzzleSelect = document.getElementById('nonogramPuzzleSelect');
+  const toolButtons = document.querySelectorAll('[data-nonogram-tool]');
+  const overlay = createOverlayController({
+    root: '#nonogramOverlay',
+    bindings: {
+      time: '#nonogramOvTime',
+      best: '#nonogramOvBest'
+    }
+  });
+  const btnRestart = document.getElementById('nonogramBtnRestart');
+  const btnClose = document.getElementById('nonogramBtnClose');
+
+  if(!gridEl || !rowCluesEl || !colCluesEl || !timerEl || !bestEl){
+    return {
+      start: () => {},
+      pause: () => {},
+      resume: () => {},
+      stop: () => {},
+      hideOverlay: () => {},
+      showOverlay: () => {}
+    };
+  }
+
+  const size = NONOGRAM_PUZZLES[0] || 'classic';
+  const cells = [];
+  let state = [];
+  function normalizePuzzle(id){
+    return NONOGRAM_PUZZLES.includes(id) ? id : size;
+  }
+
+  let currentPuzzle = normalizePuzzle(puzzleSelect ? puzzleSelect.value : size);
+  let timer = null;
+  let startTime = 0;
+  let elapsed = 0;
+  let running = false;
+  let completed = false;
+  let paused = false;
+  let menuPaused = false;
+  let activeTool = 'fill';
+
+  function bestKey(puzzleId){
+    return `${NONOGRAM_BEST_KEY_BASE}_${puzzleId}`;
+  }
+
+  function getPuzzle(puzzleId){
+    const normalized = normalizePuzzle(puzzleId);
+    return PUZZLES[normalized] || PUZZLES.classic;
+  }
+
+  function createEmptyState(rows, cols){
+    return Array.from({ length: rows }, () => Array(cols).fill('empty'));
+  }
+
+  function computeLineClues(line){
+    const clues = [];
+    let count = 0;
+    for(let i = 0; i < line.length; i++){
+      if(line[i]){
+        count++;
+      }else if(count){
+        clues.push(count);
+        count = 0;
+      }
+    }
+    if(count) clues.push(count);
+    return clues.length ? clues : [0];
+  }
+
+  function renderClues(puzzle){
+    const rows = puzzle.grid.length;
+    const cols = puzzle.grid[0].length;
+    rowCluesEl.innerHTML = '';
+    colCluesEl.innerHTML = '';
+
+    for(let r = 0; r < rows; r++){
+      const clue = document.createElement('div');
+      clue.className = 'nonogram-clue nonogram-clue--row';
+      const values = computeLineClues(puzzle.grid[r]);
+      values.forEach(value => {
+        const span = document.createElement('span');
+        span.textContent = value === 0 ? '•' : String(value);
+        clue.appendChild(span);
+      });
+      rowCluesEl.appendChild(clue);
+    }
+
+    for(let c = 0; c < cols; c++){
+      const clue = document.createElement('div');
+      clue.className = 'nonogram-clue nonogram-clue--col';
+      const column = puzzle.grid.map(row => row[c]);
+      const values = computeLineClues(column);
+      values.forEach(value => {
+        const span = document.createElement('span');
+        span.textContent = value === 0 ? '•' : String(value);
+        clue.appendChild(span);
+      });
+      colCluesEl.appendChild(clue);
+    }
+  }
+
+  function buildBoard(puzzle){
+    const rows = puzzle.grid.length;
+    const cols = puzzle.grid[0].length;
+    gridEl.innerHTML = '';
+    cells.length = 0;
+    const target = gridWrapper || gridEl;
+    target.style.setProperty('--nonogram-columns', String(cols));
+    target.style.setProperty('--nonogram-rows', String(rows));
+    rowCluesEl.style.setProperty('--nonogram-rows', String(rows));
+    colCluesEl.style.setProperty('--nonogram-columns', String(cols));
+    for(let r = 0; r < rows; r++){
+      const rowCells = [];
+      for(let c = 0; c < cols; c++){
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'nonogram-cell';
+        btn.dataset.row = String(r);
+        btn.dataset.col = String(c);
+        btn.setAttribute('aria-label', `Feld ${r + 1},${c + 1} – leer`);
+        gridEl.appendChild(btn);
+        rowCells.push(btn);
+      }
+      cells.push(rowCells);
+    }
+  }
+
+  function updateCellState(row, col){
+    const cell = cells[row]?.[col];
+    if(!cell) return;
+    const value = state[row][col];
+    cell.classList.remove('nonogram-cell--filled', 'nonogram-cell--marked');
+    let labelSuffix = 'leer';
+    if(value === 'filled'){
+      cell.classList.add('nonogram-cell--filled');
+      labelSuffix = 'ausgefüllt';
+    }else if(value === 'marked'){
+      cell.classList.add('nonogram-cell--marked');
+      labelSuffix = 'markiert';
+    }
+    cell.setAttribute('aria-label', `Feld ${Number(cell.dataset.row) + 1},${Number(cell.dataset.col) + 1} – ${labelSuffix}`);
+  }
+
+  function applyState(){
+    for(let r = 0; r < state.length; r++){
+      for(let c = 0; c < state[r].length; c++){
+        updateCellState(r, c);
+      }
+    }
+  }
+
+  function updateTimerDisplay(){
+    const seconds = Math.floor(elapsed / 1000);
+    timerEl.textContent = `Zeit: ${formatNonogramTime(seconds)}`;
+  }
+
+  function runTimer(){
+    if(timer){
+      clearInterval(timer);
+    }
+    startTime = Date.now() - elapsed;
+    timer = setInterval(() => {
+      elapsed = Date.now() - startTime;
+      updateTimerDisplay();
+    }, 250);
+  }
+
+  function pauseTimer(){
+    if(timer){
+      clearInterval(timer);
+      timer = null;
+    }
+    elapsed = Date.now() - startTime;
+    updateTimerDisplay();
+  }
+
+  function updateBestDisplay(){
+    const bestSeconds = Number(localStorage.getItem(bestKey(currentPuzzle)) || 0);
+    bestEl.textContent = bestSeconds
+      ? `Best: ${formatNonogramTime(bestSeconds)}`
+      : 'Best: --';
+  }
+
+  function checkSolved(puzzle){
+    for(let r = 0; r < puzzle.grid.length; r++){
+      for(let c = 0; c < puzzle.grid[r].length; c++){
+        const required = puzzle.grid[r][c] === 1;
+        if(required && state[r][c] !== 'filled'){
+          return false;
+        }
+        if(!required && state[r][c] === 'filled'){
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  function handleCellAction(row, col, tool){
+    if(!running || completed) return;
+    const current = state[row][col];
+    let next = current;
+    if(tool === 'fill'){
+      next = current === 'filled' ? 'empty' : 'filled';
+    }else if(tool === 'mark'){
+      next = current === 'marked' ? 'empty' : 'marked';
+    }else if(tool === 'clear'){
+      next = 'empty';
+    }
+    if(next === current) return;
+    state[row][col] = next;
+    updateCellState(row, col);
+    const puzzle = getPuzzle(currentPuzzle);
+    if(checkSolved(puzzle)){
+      completePuzzle();
+    }
+  }
+
+  function completePuzzle(){
+    pauseTimer();
+    running = false;
+    completed = true;
+    const totalSeconds = Math.max(1, Math.floor(elapsed / 1000));
+    const playerName = localStorage.getItem(PLAYER_KEY) || 'Player';
+    void addHS({
+      name: playerName,
+      time: totalSeconds,
+      date: new Date().toLocaleDateString()
+    }, currentPuzzle);
+    const bestSeconds = Number(localStorage.getItem(bestKey(currentPuzzle)) || 0);
+    if(!bestSeconds || totalSeconds < bestSeconds){
+      localStorage.setItem(bestKey(currentPuzzle), String(totalSeconds));
+    }
+    updateBestDisplay();
+    overlay.show({
+      time: formatNonogramTime(totalSeconds),
+      best: (() => {
+        const best = getBestTime(currentPuzzle);
+        return best ? formatNonogramTime(best) : '--';
+      })()
+    });
+    renderHS(currentPuzzle, { tableSelector: '#nonogramOvTable' });
+  }
+
+  function startGame(){
+    currentPuzzle = normalizePuzzle(puzzleSelect ? puzzleSelect.value : currentPuzzle);
+    if(puzzleSelect){
+      puzzleSelect.value = currentPuzzle;
+    }
+    const puzzle = getPuzzle(currentPuzzle);
+    const label = NONOGRAM_PUZZLE_LABELS[currentPuzzle] || currentPuzzle;
+    if(gridWrapper){
+      gridWrapper.setAttribute('aria-label', `Nonogramm – ${label}`);
+    }
+    gridEl.setAttribute('aria-label', `Nonogramm Gitter – ${label}`);
+    renderClues(puzzle);
+    buildBoard(puzzle);
+    state = createEmptyState(puzzle.grid.length, puzzle.grid[0].length);
+    applyState();
+    elapsed = 0;
+    completed = false;
+    running = true;
+    paused = false;
+    menuPaused = false;
+    updateTimerDisplay();
+    runTimer();
+    updateBestDisplay();
+    renderHS(currentPuzzle, { tableSelector: '#nonogramScoreTable' });
+    overlay.hide();
+  }
+
+  function pause(){
+    if(running && !completed && !paused){
+      paused = true;
+      pauseTimer();
+    }
+  }
+
+  function resume(){
+    if(running && !completed && paused){
+      paused = false;
+      runTimer();
+    }
+  }
+
+  function stop(){
+    if(running){
+      pause();
+      running = false;
+    }
+  }
+
+  gridEl.addEventListener('click', e => {
+    const target = e.target.closest('button');
+    if(!target || !gridEl.contains(target)) return;
+    const row = Number(target.dataset.row);
+    const col = Number(target.dataset.col);
+    if(Number.isNaN(row) || Number.isNaN(col)) return;
+    handleCellAction(row, col, activeTool);
+  });
+
+  gridEl.addEventListener('auxclick', e => {
+    if(e.button !== 1) return;
+    const target = e.target.closest('button');
+    if(!target || !gridEl.contains(target)) return;
+    const row = Number(target.dataset.row);
+    const col = Number(target.dataset.col);
+    if(Number.isNaN(row) || Number.isNaN(col)) return;
+    e.preventDefault();
+    handleCellAction(row, col, 'clear');
+  });
+
+  gridEl.addEventListener('contextmenu', e => {
+    const target = e.target.closest('button');
+    if(!target || !gridEl.contains(target)) return;
+    const row = Number(target.dataset.row);
+    const col = Number(target.dataset.col);
+    if(Number.isNaN(row) || Number.isNaN(col)) return;
+    e.preventDefault();
+    handleCellAction(row, col, 'mark');
+  });
+
+  function updateToolState(){
+    toolButtons.forEach(btn => {
+      const tool = btn.dataset.nonogramTool;
+      const isActive = tool === activeTool;
+      btn.classList.toggle('selected', isActive);
+      if(btn.hasAttribute('aria-pressed')){
+        btn.setAttribute('aria-pressed', String(isActive));
+      }
+    });
+  }
+
+  toolButtons.forEach(btn => {
+    const tool = btn.dataset.nonogramTool;
+    if(!tool) return;
+    btn.addEventListener('click', () => {
+      activeTool = tool;
+      updateToolState();
+      btn.focus();
+    });
+  });
+
+  updateToolState();
+
+  if(startBtn){
+    startBtn.addEventListener('click', startGame);
+  }
+
+  if(btnRestart){
+    btnRestart.addEventListener('click', () => {
+      overlay.hide();
+      startGame();
+    });
+  }
+
+  if(btnClose){
+    btnClose.addEventListener('click', () => {
+      overlay.hide();
+    });
+  }
+
+  if(puzzleSelect){
+    if(!puzzleSelect.options.length){
+      NONOGRAM_PUZZLES.forEach(id => {
+        const opt = document.createElement('option');
+        opt.value = id;
+        opt.textContent = NONOGRAM_PUZZLE_LABELS[id] || id;
+        puzzleSelect.appendChild(opt);
+      });
+      puzzleSelect.value = currentPuzzle;
+    }
+    puzzleSelect.addEventListener('change', () => {
+      currentPuzzle = normalizePuzzle(puzzleSelect.value);
+      updateBestDisplay();
+      startGame();
+    });
+  }
+
+  document.addEventListener('nonogramHsCleared', e => {
+    const mode = e.detail ? normalizePuzzle(e.detail.mode) : null;
+    if(mode && mode === currentPuzzle){
+      localStorage.removeItem(bestKey(currentPuzzle));
+      updateBestDisplay();
+      renderHS(currentPuzzle, { tableSelector: '#nonogramOvTable' });
+    }
+  });
+
+  document.addEventListener('menuToggle', e => {
+    if(!running || completed) return;
+    if(e.detail && e.detail.show){
+      menuPaused = paused;
+      pause();
+    }else if(!menuPaused){
+      resume();
+    }
+  });
+
+  startGame();
+
+  return {
+    start: startGame,
+    pause,
+    resume,
+    stop,
+    hideOverlay: overlay.hide,
+    showOverlay: overlay.show
+  };
+}

--- a/src/nonogramHighscores.js
+++ b/src/nonogramHighscores.js
@@ -1,0 +1,62 @@
+import { NONOGRAM_HS_KEY_BASE } from './constants.js';
+import {
+  createHighscoreStore,
+  sanitizeName
+} from './highscoreStore.js';
+
+const store = createHighscoreStore({
+  keyBase: NONOGRAM_HS_KEY_BASE,
+  sanitizeEntry: entry => {
+    if(!entry) return null;
+    const time = Number(entry.time);
+    if(Number.isNaN(time)) return null;
+    return {
+      name: sanitizeName(entry.name || ''),
+      time,
+      date: entry.date || new Date().toLocaleDateString()
+    };
+  },
+  sortEntries: (a, b) => a.time - b.time
+});
+
+export function formatNonogramTime(totalSeconds){
+  const seconds = Math.max(0, Math.floor(totalSeconds));
+  const minutes = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+}
+
+export function addHS(entry, puzzleId){
+  return store.add(entry, puzzleId);
+}
+
+export function clearHS(puzzleId){
+  store.clear(puzzleId);
+}
+
+export function renderHS(puzzleId, options = {}){
+  const { tableSelector = '#nonogramScoreTable' } = options;
+  const table = document.querySelector(tableSelector);
+  const tbody = table ? table.querySelector('tbody') : null;
+  if(!tbody) return;
+  const list = store.sanitizeList(store.load(puzzleId), puzzleId);
+  while(tbody.firstChild) tbody.removeChild(tbody.firstChild);
+  list.forEach((entry, index) => {
+    const tr = document.createElement('tr');
+    const tdRank = document.createElement('td');
+    tdRank.textContent = String(index + 1);
+    const tdName = document.createElement('td');
+    tdName.textContent = entry.name;
+    const tdTime = document.createElement('td');
+    tdTime.textContent = formatNonogramTime(entry.time);
+    const tdDate = document.createElement('td');
+    tdDate.textContent = entry.date || '';
+    tr.append(tdRank, tdName, tdTime, tdDate);
+    tbody.appendChild(tr);
+  });
+}
+
+export function getBestTime(puzzleId){
+  const list = store.sanitizeList(store.load(puzzleId), puzzleId);
+  return list.length ? list[0].time : null;
+}

--- a/styles.css
+++ b/styles.css
@@ -51,6 +51,14 @@
   --snake-board-surface:color-mix(in srgb,var(--accent) 18%,transparent 82%);
   --snake-board-border:color-mix(in srgb,var(--accent) 55%,transparent 45%);
   --snake-board-shadow:0 18px 40px color-mix(in srgb,var(--accent),transparent 84%);
+  --nonogram-cell-size:34px;
+  --nonogram-cell-border:color-mix(in srgb,var(--canvas-border),transparent 40%);
+  --nonogram-cell-bg:color-mix(in srgb,var(--panel-bg),transparent 18%);
+  --nonogram-cell-filled:color-mix(in srgb,var(--accent) 70%,var(--panel-bg) 30%);
+  --nonogram-cell-mark:color-mix(in srgb,var(--accent-strong) 60%,var(--panel-bg) 40%);
+  --nonogram-cell-mark-symbol:var(--panel-bg);
+  --nonogram-clue-color:color-mix(in srgb,var(--muted),transparent 10%);
+  --nonogram-clue-accent:var(--fg);
 }
 .theme-light {
   --bg:#f8fbff;
@@ -342,6 +350,7 @@ b{color:var(--fg);font-weight:600}
 .top-controls{margin-bottom:12px;gap:10px;flex-wrap:wrap}
 #snakeWrap .top-controls{justify-content:center}
 #sudokuWrap .top-controls{justify-content:center}
+#nonogramWrap .top-controls{justify-content:center}
 #snakeWrap .top-controls > *{margin-left:0;margin-right:0}
 #snakeWrap .panel > .controls:first-child{
   width:100%;
@@ -460,6 +469,39 @@ select.input option{background:var(--input-bg);color:var(--fg)}
   opacity:.35;
   pointer-events:none;
 }
+#nonogramOverlay{
+  position:fixed;
+  inset:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  opacity:0;
+  pointer-events:none;
+  transition:opacity .25s ease;
+  background:radial-gradient(circle at 50% 18%,color-mix(in srgb,var(--accent),transparent 70%) 0%,rgba(0,0,0,.75) 55%,rgba(0,0,0,.88) 100%);
+  backdrop-filter:blur(3px) saturate(1.12);
+  z-index:9999;
+  padding:18px;
+  box-sizing:border-box;
+}
+#nonogramOverlay.show{
+  opacity:1;
+  pointer-events:auto;
+}
+#nonogramOverlay .overlay-card{
+  position:relative;
+  background:linear-gradient(150deg,color-mix(in srgb,var(--stat-bg),transparent 12%) 0%,color-mix(in srgb,var(--accent),transparent 80%) 100%);
+  border:1px solid color-mix(in srgb,var(--accent),transparent 55%);
+  border-radius:20px;
+  padding:24px 26px;
+  min-width:320px;
+  max-width:90vw;
+  max-height:calc(100vh - 72px);
+  overflow:auto;
+  box-shadow:0 24px 52px color-mix(in srgb,var(--accent),transparent 82%),0 18px 36px color-mix(in srgb,var(--bg),#000 55%);
+  animation:pop .3s ease-out;
+}
+#nonogramOverlay h2{margin:0 0 8px;font-weight:700;letter-spacing:.5px;}
 #sudokuOverlay h2{
   margin:0 0 6px;
   font-weight:600;
@@ -793,12 +835,196 @@ dialog::backdrop{background:rgba(0,0,0,.45)}
   font-weight:700;
   box-shadow:0 0 0 3px color-mix(in srgb,var(--accent),transparent 35%) inset;
 }
+.nonogram-panel{
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:18px;
+}
+.nonogram-grid{
+  --nonogram-columns:10;
+  --nonogram-rows:10;
+  --nonogram-clue-offset:calc(var(--nonogram-cell-size) * 2.4);
+  position:relative;
+  display:grid;
+  grid-template-columns:var(--nonogram-clue-offset) minmax(0,1fr);
+  grid-template-rows:var(--nonogram-clue-offset) minmax(0,1fr);
+  border:4px solid color-mix(in srgb,var(--accent),transparent 65%);
+  border-radius:20px;
+  background:linear-gradient(160deg,color-mix(in srgb,var(--panel-bg),transparent 6%),color-mix(in srgb,var(--panel-bg),transparent 18%));
+  box-shadow:0 26px 50px color-mix(in srgb,var(--bg),#000 42%),0 16px 32px color-mix(in srgb,var(--accent),transparent 82%);
+  overflow:hidden;
+}
+.nonogram-grid__corner{
+  grid-column:1;
+  grid-row:1;
+  min-width:var(--nonogram-clue-offset);
+  min-height:var(--nonogram-clue-offset);
+  border-right:1px solid color-mix(in srgb,var(--nonogram-cell-border),transparent 35%);
+  border-bottom:1px solid color-mix(in srgb,var(--nonogram-cell-border),transparent 35%);
+  background:color-mix(in srgb,var(--panel-bg),transparent 12%);
+}
+.nonogram-clues{
+  display:grid;
+  color:var(--nonogram-clue-color);
+  font-weight:600;
+  font-size:.85rem;
+  letter-spacing:.02em;
+}
+.nonogram-clues--cols{
+  grid-column:2;
+  grid-row:1;
+  grid-template-columns:repeat(var(--nonogram-columns),var(--nonogram-cell-size));
+  gap:4px;
+  padding:10px 12px 16px;
+  align-items:end;
+  justify-items:center;
+  min-height:var(--nonogram-clue-offset);
+}
+.nonogram-clues--rows{
+  grid-column:1;
+  grid-row:2;
+  grid-template-rows:repeat(var(--nonogram-rows),var(--nonogram-cell-size));
+  gap:4px;
+  padding:16px 12px 16px 12px;
+  justify-items:end;
+  align-items:center;
+  min-width:var(--nonogram-clue-offset);
+}
+.nonogram-clue{
+  display:flex;
+  gap:6px;
+  align-items:center;
+  justify-content:center;
+  white-space:nowrap;
+}
+.nonogram-clue--col{
+  flex-direction:column;
+  justify-content:flex-end;
+  min-height:100%;
+}
+.nonogram-clue--row{
+  justify-content:flex-end;
+}
+.nonogram-clue span{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  min-width:1.3em;
+  padding:0 4px;
+  border-radius:6px;
+}
+.nonogram-cells{
+  grid-column:2;
+  grid-row:2;
+  display:grid;
+  grid-template-columns:repeat(var(--nonogram-columns),var(--nonogram-cell-size));
+  grid-template-rows:repeat(var(--nonogram-rows),var(--nonogram-cell-size));
+  gap:3px;
+  padding:14px;
+  border:2px solid var(--nonogram-cell-border);
+  border-radius:16px;
+  background:var(--canvas-bg);
+  box-shadow:0 20px 48px color-mix(in srgb,var(--accent),transparent 85%) inset;
+}
+.nonogram-cell{
+  width:var(--nonogram-cell-size);
+  height:var(--nonogram-cell-size);
+  border:1px solid var(--nonogram-cell-border);
+  border-radius:8px;
+  background:var(--nonogram-cell-bg);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  color:var(--fg);
+  cursor:pointer;
+  transition:background .15s ease,border-color .15s ease,box-shadow .15s ease,transform .15s ease;
+}
+.nonogram-cell:hover{
+  border-color:color-mix(in srgb,var(--accent),transparent 45%);
+  transform:translateY(-1px);
+}
+.nonogram-cell:focus-visible{
+  outline:none;
+  border-color:color-mix(in srgb,var(--accent),transparent 25%);
+  box-shadow:0 0 0 3px color-mix(in srgb,var(--accent),transparent 60%);
+}
+.nonogram-cell--filled{
+  background:var(--nonogram-cell-filled);
+  border-color:color-mix(in srgb,var(--accent),transparent 25%);
+  box-shadow:0 8px 18px color-mix(in srgb,var(--accent),transparent 68%) inset;
+}
+.nonogram-cell--marked{
+  border-color:color-mix(in srgb,var(--accent-strong),transparent 35%);
+}
+.nonogram-cell--marked::after{
+  content:'✕';
+  color:var(--nonogram-cell-mark);
+  font-size:1.1em;
+  font-weight:700;
+  line-height:1;
+}
+.nonogram-tools{
+  display:flex;
+  gap:12px;
+  flex-wrap:wrap;
+  justify-content:center;
+}
+.nonogram-tool{
+  display:flex;
+  align-items:center;
+  gap:6px;
+  padding:10px 18px;
+  font-weight:600;
+  border-radius:12px;
+}
+.nonogram-tool .icon{font-size:1.1em;}
+.nonogram-tool:not(.button-primary){
+  border:1px solid var(--button-border);
+  background:var(--button-bg);
+  color:var(--fg);
+  transition:background .2s ease,border-color .2s ease,box-shadow .2s ease;
+}
+.nonogram-tool:not(.button-primary):hover{
+  background:var(--button-hover-bg);
+  border-color:color-mix(in srgb,var(--accent),transparent 55%);
+}
+.nonogram-tool.selected,
+.nonogram-tool[aria-pressed="true"]{
+  border-color:color-mix(in srgb,var(--accent),transparent 30%);
+}
+.nonogram-tool.selected:not(.button-primary),
+.nonogram-tool[aria-pressed="true"]:not(.button-primary){
+  box-shadow:0 0 0 2px color-mix(in srgb,var(--accent),transparent 55%) inset;
+  background:color-mix(in srgb,var(--accent),transparent 82%);
+  color:var(--nonogram-clue-accent);
+}
+.nonogram-tool.selected.button-primary,
+.nonogram-tool[aria-pressed="true"].button-primary{
+  box-shadow:var(--button-primary-hover-shadow);
+}
 @media (max-width:640px){
   .sudoku-panel{gap:14px;}
 }
 @media (max-width:480px){
   .sudoku-pad{padding:10px 12px 14px;}
   .sudoku-pad button{font-size:clamp(15px,6vw,18px);padding:12px;}
+}
+@media (max-width:700px){
+  .nonogram-grid{
+    --nonogram-cell-size:30px;
+    --nonogram-clue-offset:calc(var(--nonogram-cell-size) * 2.2);
+  }
+}
+@media (max-width:480px){
+  .nonogram-grid{
+    --nonogram-cell-size:24px;
+    --nonogram-clue-offset:calc(var(--nonogram-cell-size) * 2.6);
+  }
+  .nonogram-tool{
+    flex:1 1 45%;
+    justify-content:center;
+  }
 }
 @keyframes sudoku-error{0%,100%{background:color-mix(in srgb,#b00020,transparent 75%);color:var(--fg)}50%{background:#b00020;color:#fff}}
 @keyframes sudoku-highlight-band{0%,100%{box-shadow:0 0 0 1px color-mix(in srgb,var(--accent),transparent 55%) inset;}50%{box-shadow:0 0 0 4px color-mix(in srgb,var(--accent),transparent 70%) inset;}}


### PR DESCRIPTION
## Summary
- add a 10×10 Nonogram puzzle with timer, overlay and solve tools
- wire the new game into the menu, mode selectors and highscore handling
- style the grid, clues and overlay to match the existing aesthetic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e24cf14a74832b9288a8eaa34a7962