### PR TITLE
Expand nonogram puzzle set and randomize restarts

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -100,9 +100,13 @@ export const SUDOKU_DIFFICULTY_LABELS = {
 export const SUDOKU_HS_KEY_BASE = 'sudoku_highscores_v1';
 export const SUDOKU_BEST_KEY_BASE = 'sudoku_best_v1';
 
-export const NONOGRAM_PUZZLES = ['classic'];
+export const NONOGRAM_PUZZLES = ['classic', 'smiley', 'space', 'tree', 'house'];
 export const NONOGRAM_PUZZLE_LABELS = {
-  classic: '10×10 Rätsel'
+  classic: 'Pixel-Herz (10×10)',
+  smiley: 'Smiley (10×10)',
+  space: 'Space-Invader (10×10)',
+  tree: 'Winterbaum (10×10)',
+  house: 'Haus (10×10)'
 };
 export const NONOGRAM_HS_KEY_BASE = 'nonogram_highscores_v1';
 export const NONOGRAM_BEST_KEY_BASE = 'nonogram_best_v1';

--- a/src/nonogram.js
+++ b/src/nonogram.js
@@ -27,6 +27,66 @@ const PUZZLES = {
       [0,0,0,0,1,0,0,0,0,0],
       [0,0,0,0,1,0,0,0,0,0]
     ]
+  },
+  smiley: {
+    title: 'Smiley',
+    grid: [
+      [0,0,1,1,1,1,1,1,0,0],
+      [0,1,0,0,0,0,0,0,1,0],
+      [1,0,1,0,0,0,0,1,0,1],
+      [1,0,1,0,0,0,0,1,0,1],
+      [1,0,0,0,0,0,0,0,0,1],
+      [1,0,0,0,0,0,0,0,0,1],
+      [1,0,1,0,0,0,0,1,0,1],
+      [1,0,0,1,1,1,1,0,0,1],
+      [0,1,0,0,0,0,0,0,1,0],
+      [0,0,1,1,1,1,1,1,0,0]
+    ]
+  },
+  space: {
+    title: 'Space-Invader',
+    grid: [
+      [0,0,1,1,1,1,1,1,0,0],
+      [0,1,1,1,1,1,1,1,1,0],
+      [1,1,0,1,1,1,1,0,1,1],
+      [1,1,1,1,1,1,1,1,1,1],
+      [1,1,1,0,1,1,0,1,1,1],
+      [1,1,1,1,1,1,1,1,1,1],
+      [0,1,1,0,0,0,0,1,1,0],
+      [0,0,1,1,0,0,1,1,0,0],
+      [0,0,1,0,0,0,0,1,0,0],
+      [0,1,0,0,0,0,0,0,1,0]
+    ]
+  },
+  tree: {
+    title: 'Winterbaum',
+    grid: [
+      [0,0,0,0,0,1,0,0,0,0],
+      [0,0,0,0,1,1,1,0,0,0],
+      [0,0,0,1,1,1,1,1,0,0],
+      [0,0,1,1,1,1,1,1,1,0],
+      [0,1,1,1,1,1,1,1,1,1],
+      [0,0,0,0,0,1,0,0,0,0],
+      [0,0,0,0,0,1,0,0,0,0],
+      [0,0,0,0,0,1,0,0,0,0],
+      [0,0,0,0,1,1,1,0,0,0],
+      [0,0,0,1,1,1,1,1,0,0]
+    ]
+  },
+  house: {
+    title: 'Haus',
+    grid: [
+      [0,0,0,0,0,1,0,0,0,0],
+      [0,0,0,0,1,1,1,0,0,0],
+      [0,0,0,1,1,1,1,1,0,0],
+      [0,0,1,1,1,1,1,1,1,0],
+      [0,1,1,1,1,1,1,1,1,1],
+      [1,1,1,0,0,0,0,0,1,1],
+      [1,0,0,1,0,0,1,0,0,1],
+      [1,0,0,1,1,1,1,0,0,1],
+      [1,0,0,1,0,0,1,0,0,1],
+      [1,1,1,1,1,1,1,1,1,1]
+    ]
   }
 };
 
@@ -66,6 +126,20 @@ export function initNonogram(){
   let state = [];
   function normalizePuzzle(id){
     return NONOGRAM_PUZZLES.includes(id) ? id : size;
+  }
+
+  function listAvailablePuzzles(){
+    return NONOGRAM_PUZZLES.filter(Boolean).map(normalizePuzzle);
+  }
+
+  function pickRandomPuzzle(excludeId){
+    const available = listAvailablePuzzles();
+    const pool = excludeId ? available.filter(id => id !== excludeId) : [...available];
+    if(!pool.length){
+      pool.push(...(available.length ? available : [size]));
+    }
+    const index = Math.floor(Math.random() * pool.length);
+    return normalizePuzzle(pool[index] ?? size);
   }
 
   let currentPuzzle = normalizePuzzle(puzzleSelect ? puzzleSelect.value : size);
@@ -383,7 +457,14 @@ export function initNonogram(){
   updateToolState();
 
   if(startBtn){
-    startBtn.addEventListener('click', startGame);
+    startBtn.addEventListener('click', () => {
+      const nextPuzzle = pickRandomPuzzle(currentPuzzle);
+      if(puzzleSelect){
+        puzzleSelect.value = nextPuzzle;
+      }
+      currentPuzzle = nextPuzzle;
+      startGame();
+    });
   }
 
   if(btnRestart){
@@ -400,15 +481,14 @@ export function initNonogram(){
   }
 
   if(puzzleSelect){
-    if(!puzzleSelect.options.length){
-      NONOGRAM_PUZZLES.forEach(id => {
-        const opt = document.createElement('option');
-        opt.value = id;
-        opt.textContent = NONOGRAM_PUZZLE_LABELS[id] || id;
-        puzzleSelect.appendChild(opt);
-      });
-      puzzleSelect.value = currentPuzzle;
-    }
+    puzzleSelect.innerHTML = '';
+    NONOGRAM_PUZZLES.forEach(id => {
+      const opt = document.createElement('option');
+      opt.value = id;
+      opt.textContent = NONOGRAM_PUZZLE_LABELS[id] || id;
+      puzzleSelect.appendChild(opt);
+    });
+    puzzleSelect.value = currentPuzzle;
     puzzleSelect.addEventListener('change', () => {
       currentPuzzle = normalizePuzzle(puzzleSelect.value);
       updateBestDisplay();


### PR DESCRIPTION
## Summary
- add four new nonogram puzzle definitions with descriptive labels
- randomize the "Neues Rätsel" button so it loads a different puzzle when possible
- rebuild the puzzle selector on init so all puzzles are available in the dropdown

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e2cc767c9c832b9629e77734c77d5b