### PR TITLE
Refine Nonogram board layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -52,12 +52,12 @@
   --snake-board-border:color-mix(in srgb,var(--accent) 55%,transparent 45%);
   --snake-board-shadow:0 18px 40px color-mix(in srgb,var(--accent),transparent 84%);
   --nonogram-cell-size:34px;
-  --nonogram-cell-border:color-mix(in srgb,var(--canvas-border),transparent 40%);
-  --nonogram-cell-bg:color-mix(in srgb,var(--panel-bg),transparent 18%);
-  --nonogram-cell-filled:color-mix(in srgb,var(--accent) 70%,var(--panel-bg) 30%);
-  --nonogram-cell-mark:color-mix(in srgb,var(--accent-strong) 60%,var(--panel-bg) 40%);
-  --nonogram-cell-mark-symbol:var(--panel-bg);
-  --nonogram-clue-color:color-mix(in srgb,var(--muted),transparent 10%);
+  --nonogram-cell-border:color-mix(in srgb,var(--canvas-border),transparent 20%);
+  --nonogram-cell-bg:#ffffff;
+  --nonogram-cell-filled:color-mix(in srgb,var(--accent) 25%,#ffffff 75%);
+  --nonogram-cell-mark:color-mix(in srgb,var(--accent-strong) 55%,#ffffff 45%);
+  --nonogram-cell-mark-symbol:var(--fg);
+  --nonogram-clue-color:color-mix(in srgb,var(--muted),transparent 20%);
   --nonogram-clue-accent:var(--fg);
 }
 .theme-light {
@@ -111,6 +111,12 @@
   --snake-board-surface:#ffffff;
   --snake-board-border:color-mix(in srgb,var(--accent) 35%,transparent 65%);
   --snake-board-shadow:0 18px 34px color-mix(in srgb,var(--accent),transparent 86%);
+  --nonogram-cell-border:color-mix(in srgb,var(--canvas-border),transparent 35%);
+  --nonogram-cell-bg:#ffffff;
+  --nonogram-cell-filled:color-mix(in srgb,var(--accent) 18%,#ffffff 82%);
+  --nonogram-cell-mark:color-mix(in srgb,var(--accent-strong) 45%,#ffffff 55%);
+  --nonogram-cell-mark-symbol:var(--fg);
+  --nonogram-clue-color:color-mix(in srgb,var(--muted),transparent 35%);
 }
 
 .theme-aurora {
@@ -164,6 +170,12 @@
   --snake-board-surface:color-mix(in srgb,var(--accent) 24%,transparent 76%);
   --snake-board-border:color-mix(in srgb,var(--accent) 65%,transparent 35%);
   --snake-board-shadow:0 24px 52px color-mix(in srgb,var(--accent-strong),transparent 78%);
+  --nonogram-cell-border:color-mix(in srgb,var(--canvas-border),transparent 18%);
+  --nonogram-cell-bg:#ffffff;
+  --nonogram-cell-filled:color-mix(in srgb,var(--accent) 28%,#ffffff 72%);
+  --nonogram-cell-mark:color-mix(in srgb,var(--accent-strong) 55%,#ffffff 45%);
+  --nonogram-cell-mark-symbol:var(--fg);
+  --nonogram-clue-color:color-mix(in srgb,var(--muted),transparent 22%);
 }
 *,*::before,*::after{box-sizing:border-box}
 
@@ -849,20 +861,20 @@ dialog::backdrop{background:rgba(0,0,0,.45)}
   display:grid;
   grid-template-columns:var(--nonogram-clue-offset) minmax(0,1fr);
   grid-template-rows:var(--nonogram-clue-offset) minmax(0,1fr);
-  border:4px solid color-mix(in srgb,var(--accent),transparent 65%);
-  border-radius:20px;
-  background:linear-gradient(160deg,color-mix(in srgb,var(--panel-bg),transparent 6%),color-mix(in srgb,var(--panel-bg),transparent 18%));
-  box-shadow:0 26px 50px color-mix(in srgb,var(--bg),#000 42%),0 16px 32px color-mix(in srgb,var(--accent),transparent 82%);
-  overflow:hidden;
+  border:2px solid var(--nonogram-cell-border);
+  background:var(--panel-bg);
+  max-width:100%;
+  max-height:100%;
+  overflow:auto;
 }
 .nonogram-grid__corner{
   grid-column:1;
   grid-row:1;
   min-width:var(--nonogram-clue-offset);
   min-height:var(--nonogram-clue-offset);
-  border-right:1px solid color-mix(in srgb,var(--nonogram-cell-border),transparent 35%);
-  border-bottom:1px solid color-mix(in srgb,var(--nonogram-cell-border),transparent 35%);
-  background:color-mix(in srgb,var(--panel-bg),transparent 12%);
+  border-right:1px solid var(--nonogram-cell-border);
+  border-bottom:1px solid var(--nonogram-cell-border);
+  background:var(--panel-bg);
 }
 .nonogram-clues{
   display:grid;
@@ -870,13 +882,14 @@ dialog::backdrop{background:rgba(0,0,0,.45)}
   font-weight:600;
   font-size:.85rem;
   letter-spacing:.02em;
+  background:var(--panel-bg);
 }
 .nonogram-clues--cols{
   grid-column:2;
   grid-row:1;
   grid-template-columns:repeat(var(--nonogram-columns),var(--nonogram-cell-size));
-  gap:4px;
-  padding:10px 12px 16px;
+  gap:2px;
+  padding:8px 8px 12px;
   align-items:end;
   justify-items:center;
   min-height:var(--nonogram-clue-offset);
@@ -885,15 +898,15 @@ dialog::backdrop{background:rgba(0,0,0,.45)}
   grid-column:1;
   grid-row:2;
   grid-template-rows:repeat(var(--nonogram-rows),var(--nonogram-cell-size));
-  gap:4px;
-  padding:16px 12px 16px 12px;
+  gap:2px;
+  padding:12px 8px 12px 8px;
   justify-items:end;
   align-items:center;
   min-width:var(--nonogram-clue-offset);
 }
 .nonogram-clue{
   display:flex;
-  gap:6px;
+  gap:4px;
   align-items:center;
   justify-content:center;
   white-space:nowrap;
@@ -912,7 +925,6 @@ dialog::backdrop{background:rgba(0,0,0,.45)}
   justify-content:center;
   min-width:1.3em;
   padding:0 4px;
-  border-radius:6px;
 }
 .nonogram-cells{
   grid-column:2;
@@ -920,42 +932,37 @@ dialog::backdrop{background:rgba(0,0,0,.45)}
   display:grid;
   grid-template-columns:repeat(var(--nonogram-columns),var(--nonogram-cell-size));
   grid-template-rows:repeat(var(--nonogram-rows),var(--nonogram-cell-size));
-  gap:3px;
-  padding:14px;
-  border:2px solid var(--nonogram-cell-border);
-  border-radius:16px;
-  background:var(--canvas-bg);
-  box-shadow:0 20px 48px color-mix(in srgb,var(--accent),transparent 85%) inset;
+  gap:0;
+  border:1px solid var(--nonogram-cell-border);
+  background:var(--nonogram-cell-border);
 }
 .nonogram-cell{
+  box-sizing:border-box;
   width:var(--nonogram-cell-size);
   height:var(--nonogram-cell-size);
   border:1px solid var(--nonogram-cell-border);
-  border-radius:8px;
   background:var(--nonogram-cell-bg);
   display:flex;
   align-items:center;
   justify-content:center;
   color:var(--fg);
   cursor:pointer;
-  transition:background .15s ease,border-color .15s ease,box-shadow .15s ease,transform .15s ease;
+  transition:background .12s ease,border-color .12s ease;
 }
 .nonogram-cell:hover{
   border-color:color-mix(in srgb,var(--accent),transparent 45%);
-  transform:translateY(-1px);
 }
 .nonogram-cell:focus-visible{
-  outline:none;
-  border-color:color-mix(in srgb,var(--accent),transparent 25%);
-  box-shadow:0 0 0 3px color-mix(in srgb,var(--accent),transparent 60%);
+  outline:2px solid color-mix(in srgb,var(--accent),transparent 35%);
+  outline-offset:-2px;
 }
 .nonogram-cell--filled{
   background:var(--nonogram-cell-filled);
-  border-color:color-mix(in srgb,var(--accent),transparent 25%);
-  box-shadow:0 8px 18px color-mix(in srgb,var(--accent),transparent 68%) inset;
+  border-color:color-mix(in srgb,var(--accent),transparent 35%);
 }
 .nonogram-cell--marked{
-  border-color:color-mix(in srgb,var(--accent-strong),transparent 35%);
+  background:var(--nonogram-cell-bg);
+  border-color:color-mix(in srgb,var(--nonogram-cell-mark),transparent 40%);
 }
 .nonogram-cell--marked::after{
   content:'✕';


### PR DESCRIPTION
## Summary
- restyle the Nonogram board with crisp square cells and responsive grid scrolling
- ensure cells start white and update filled/marked colors for better readability
- tidy clue spacing to prevent overlap and keep the entire puzzle visible

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e2cb033d98832b8e4cd85b7dfb6321