### PR TITLE
Refactor highscore rendering to reuse shared utilities

### DIFF
--- a/src/nonogramHighscores.js
+++ b/src/nonogramHighscores.js
@@ -1,6 +1,8 @@
 import { NONOGRAM_HS_KEY_BASE } from './constants.js';
 import {
   createHighscoreStore,
+  formatDuration,
+  renderHighscoreTable,
   sanitizeName
 } from './highscoreStore.js';
 
@@ -20,10 +22,7 @@ const store = createHighscoreStore({
 });
 
 export function formatNonogramTime(totalSeconds){
-  const seconds = Math.max(0, Math.floor(totalSeconds));
-  const minutes = Math.floor(seconds / 60);
-  const secs = seconds % 60;
-  return `${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+  return formatDuration(totalSeconds);
 }
 
 export function addHS(entry, puzzleId){
@@ -36,31 +35,23 @@ export function clearHS(puzzleId){
 
 export function renderHS(puzzleId, options = {}){
   const { tableSelector = '#nonogramScoreTable' } = options;
-  const table = document.querySelector(tableSelector);
-  const tbody = table ? table.querySelector('tbody') : null;
-  if(!tbody) return;
-  const list = getHighscores(puzzleId);
-  while(tbody.firstChild) tbody.removeChild(tbody.firstChild);
-  list.forEach((entry, index) => {
-    const tr = document.createElement('tr');
-    const tdRank = document.createElement('td');
-    tdRank.textContent = String(index + 1);
-    const tdName = document.createElement('td');
-    tdName.textContent = entry.name;
-    const tdTime = document.createElement('td');
-    tdTime.textContent = formatNonogramTime(entry.time);
-    const tdDate = document.createElement('td');
-    tdDate.textContent = entry.date || '';
-    tr.append(tdRank, tdName, tdTime, tdDate);
-    tbody.appendChild(tr);
+  return renderHighscoreTable({
+    store,
+    mode: puzzleId,
+    tableSelector,
+    formatRow: entry => [
+      entry.name,
+      formatDuration(entry.time),
+      entry.date || ''
+    ]
   });
 }
 
 export function getBestTime(puzzleId){
-  const list = getHighscores(puzzleId);
+  const list = store.getListSync(puzzleId);
   return list.length ? list[0].time : null;
 }
 
 export function getHighscores(puzzleId){
-  return store.sanitizeList(store.load(puzzleId), puzzleId);
+  return store.getListSync(puzzleId);
 }

--- a/src/snakeHighscores.js
+++ b/src/snakeHighscores.js
@@ -1,6 +1,10 @@
 // Highscore storage and rendering for Snake
 import { SNAKE_HS_KEY_BASE } from './constants.js';
-import { createHighscoreStore, sanitizeName } from './highscoreStore.js';
+import {
+  createHighscoreStore,
+  renderHighscoreTable,
+  sanitizeName
+} from './highscoreStore.js';
 
 const LEGACY_HS_KEY = 'snake_hs';
 
@@ -35,24 +39,12 @@ export function addHS(entry, mode) {
   return store.add(entry, mode);
 }
 
-export async function renderHS(mode, options = {}) {
+export function renderHS(mode, options = {}) {
   const { tableSelector = '#snakeHsTable' } = options;
-  const table = document.querySelector(tableSelector);
-  const tbody = table ? table.querySelector('tbody') : null;
-  if(!tbody) return;
-  const list = await store.getList(mode);
-  while(tbody.firstChild) tbody.removeChild(tbody.firstChild);
-  list.forEach((e,i)=>{
-    const tr = document.createElement('tr');
-    const tdRank = document.createElement('td');
-    tdRank.textContent = String(i+1);
-    const tdName = document.createElement('td');
-    tdName.textContent = e.name;
-    const tdScore = document.createElement('td');
-    tdScore.textContent = String(e.score);
-    const tdDate = document.createElement('td');
-    tdDate.textContent = e.date;
-    tr.append(tdRank, tdName, tdScore, tdDate);
-    tbody.appendChild(tr);
+  return renderHighscoreTable({
+    store,
+    mode,
+    tableSelector,
+    formatRow: entry => [entry.name, entry.score, entry.date]
   });
 }

--- a/src/sudokuHighscores.js
+++ b/src/sudokuHighscores.js
@@ -2,6 +2,8 @@
 import { SUDOKU_HS_KEY_BASE } from './constants.js';
 import {
   createHighscoreStore,
+  formatDuration,
+  renderHighscoreTable,
   sanitizeName
 } from './highscoreStore.js';
 
@@ -21,14 +23,7 @@ const store = createHighscoreStore({
 });
 
 export function formatTime(totalSeconds){
-  const seconds = Math.max(0, Math.floor(totalSeconds));
-  const hrs = Math.floor(seconds / 3600);
-  const mins = Math.floor((seconds % 3600) / 60);
-  const secs = seconds % 60;
-  if(hrs > 0){
-    return `${hrs}:${String(mins).padStart(2,'0')}:${String(secs).padStart(2,'0')}`;
-  }
-  return `${String(mins).padStart(2,'0')}:${String(secs).padStart(2,'0')}`;
+  return formatDuration(totalSeconds, { allowHours: true });
 }
 
 export function addHS(entry, difficulty){
@@ -41,27 +36,19 @@ export function clearHS(difficulty){
 
 export function renderHS(difficulty, options = {}){
   const { tableSelector = '#sudokuScoreTable' } = options;
-  const table = document.querySelector(tableSelector);
-  const tbody = table ? table.querySelector('tbody') : null;
-  if(!tbody) return;
-  const list = store.sanitizeList(store.load(difficulty), difficulty);
-  while(tbody.firstChild) tbody.removeChild(tbody.firstChild);
-  list.forEach((entry, index) => {
-    const tr = document.createElement('tr');
-    const tdRank = document.createElement('td');
-    tdRank.textContent = String(index + 1);
-    const tdName = document.createElement('td');
-    tdName.textContent = entry.name;
-    const tdTime = document.createElement('td');
-    tdTime.textContent = formatTime(entry.time);
-    const tdDate = document.createElement('td');
-    tdDate.textContent = entry.date || '';
-    tr.append(tdRank, tdName, tdTime, tdDate);
-    tbody.appendChild(tr);
+  return renderHighscoreTable({
+    store,
+    mode: difficulty,
+    tableSelector,
+    formatRow: entry => [
+      entry.name,
+      formatDuration(entry.time, { allowHours: true }),
+      entry.date || ''
+    ]
   });
 }
 
 export function getBestTime(difficulty){
-  const list = store.sanitizeList(store.load(difficulty), difficulty);
+  const list = store.getListSync(difficulty);
   return list.length ? list[0].time : null;
 }


### PR DESCRIPTION
## Summary
- add reusable renderHighscoreTable and formatDuration helpers to the shared highscore store
- refactor snake, sudoku, and nonogram highscores to build tables via the shared helper
- expose a synchronous highscore getter for callers that need immediate access

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e566b61798832ba2fd9945b2d68879