### PR TITLE
Set beige theme as default

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -1,14 +1,17 @@
 import { THEME_KEY, PLAYER_KEY } from './constants.js';
 
 export function initUI(){
-  const prefersLight = window.matchMedia('(prefers-color-scheme: light)').matches;
-  const storedTheme = localStorage.getItem(THEME_KEY);
-  const themeOrder = ['dark','light','aurora'];
+  let storedTheme = localStorage.getItem(THEME_KEY);
+  const themeOrder = ['beige','light','aurora'];
   const themeConfig = {
-    dark:{ className:'', icon:'🌙', label:'Dunkel' },
+    beige:{ className:'', icon:'🌓', label:'Beige' },
     light:{ className:'theme-light', icon:'🌞', label:'Hell' },
     aurora:{ className:'theme-aurora', icon:'⚡', label:'Aurora' }
   };
+  if(storedTheme === 'dark'){
+    storedTheme = 'beige';
+    localStorage.setItem(THEME_KEY, storedTheme);
+  }
   const removableClasses = themeOrder
     .map(key => themeConfig[key]?.className)
     .filter(Boolean);
@@ -24,7 +27,7 @@ export function initUI(){
 
   let currentTheme = themeOrder.includes(storedTheme)
     ? storedTheme
-    : (storedTheme === null && prefersLight ? 'light' : 'dark');
+    : 'beige';
   applyTheme(currentTheme);
 
   const btnThemes = document.querySelectorAll('#themeToggle');
@@ -57,7 +60,7 @@ export function initUI(){
     document.dispatchEvent(evt);
   }
   function updateThemeIcon(){
-    const config = themeConfig[currentTheme] ?? themeConfig.dark;
+    const config = themeConfig[currentTheme] ?? themeConfig.beige;
     themeIcons.forEach(icon => {
       icon.textContent = config.icon;
     });

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -27,8 +27,8 @@ if (!JSDOM) {
     const btn = document.getElementById('themeToggle');
     const icon = document.querySelector('[data-theme-icon]');
 
-    assert.strictEqual(icon.textContent, '🌙');
-    assert.strictEqual(document.body.dataset.theme, 'dark');
+    assert.strictEqual(icon.textContent, '🌓');
+    assert.strictEqual(document.body.dataset.theme, 'beige');
 
     btn.dispatchEvent(new window.Event('click'));
 
@@ -44,9 +44,9 @@ if (!JSDOM) {
 
     btn.dispatchEvent(new window.Event('click'));
 
-    assert.strictEqual(localStorage.getItem(THEME_KEY), 'dark');
-    assert.strictEqual(document.body.dataset.theme, 'dark');
-    assert.strictEqual(icon.textContent, '🌙');
+    assert.strictEqual(localStorage.getItem(THEME_KEY), 'beige');
+    assert.strictEqual(document.body.dataset.theme, 'beige');
+    assert.strictEqual(icon.textContent, '🌓');
 
     delete global.window;
     delete global.document;


### PR DESCRIPTION
## Summary
- set the beige theme with a half-moon icon as the default selection and migrate stored dark preferences
- update the theme toggle test expectations to reflect the new theme cycle

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e56bfc5208832b939fe1a1cbf50153